### PR TITLE
feat: add basic expression evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "evalexpr"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3b4e80fd8edee77d6fc35d59862d5765dae7512a95f49fd7bf03847c85b26a"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +547,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "derive_builder",
+ "evalexpr",
  "im",
  "indexmap 1.9.3",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,11 @@ solvent = { version = "0.8.3", features = ["deterministic"] }
 url = "2.4.0"
 rust-embed = "6.8.1"
 task_partitioner = "0.1.1"
+
 clap_complete = "4.3.2"
 clap_mangen = "0.2.12"
 camino = { version = "1.1.6", features = ["serde1"] }
-
+evalexpr = "11.0.0"
 
 [profile.release]
 lto = "fat"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -835,7 +835,7 @@ fn configure_build(
     global_env_flattened.insert(&out_string, outfile.to_string());
     let tasks = build
         .build_context
-        .collect_tasks(contexts, &global_env_flattened);
+        .collect_tasks(contexts, &global_env_flattened)?;
 
     Ok(Some((
         BuildInfo {

--- a/src/model/task.rs
+++ b/src/model/task.rs
@@ -30,6 +30,7 @@ impl Task {
             use shell_words::join;
             use std::process::Command;
             let mut command = Command::new("sh");
+            let cmd = cmd.replace("$$", "$");
             if verbose > 0 {
                 command.arg("-x");
             }
@@ -55,19 +56,15 @@ impl Task {
         Ok(())
     }
 
-    pub fn with_env(&self, env: &im::HashMap<&String, String>) -> Task {
-        Task {
+    pub fn with_env(&self, env: &im::HashMap<&String, String>) -> Result<Task, Error> {
+        Ok(Task {
             build: self.build,
             cmd: self
                 .cmd
                 .iter()
-                .map(|cmd| {
-                    nested_env::expand(cmd, env, nested_env::IfMissing::Ignore)
-                        .unwrap()
-                        .replace("$$", "$")
-                })
-                .collect(),
+                .map(|cmd| nested_env::expand(cmd, env, nested_env::IfMissing::Ignore))
+                .collect::<Result<Vec<String>, _>>()?,
             ignore_ctrl_c: self.ignore_ctrl_c,
-        }
+        })
     }
 }

--- a/src/nested_env/expr.rs
+++ b/src/nested_env/expr.rs
@@ -1,0 +1,85 @@
+use std::borrow::Cow;
+
+use evalexpr::EvalexprError;
+
+pub fn eval<'a>(input: &'a str) -> Result<Cow<'a, str>, EvalexprError> {
+    eval_recursive(input, false)
+}
+
+fn eval_recursive<'a>(input: &'a str, is_eval: bool) -> Result<Cow<'a, str>, EvalexprError> {
+    let mut result = String::new();
+    let mut start = 0;
+    let mut level = 0;
+    let mut input_changed = false;
+
+    for (i, character) in input.char_indices() {
+        if character == '$'
+            && i + 1 < input.len()
+            && input[i + 1..i + 2] == *"("
+            && (i == 0 || (input[i - 1..i] != *"$"))
+        {
+            if level == 0 {
+                start = i + 1;
+            }
+        } else if character == '(' && start > 0 {
+            level += 1;
+        } else if character == ')' && level > 0 && start > 0 {
+            level -= 1;
+            if level == 0 {
+                input_changed = true;
+                result.push_str(&eval_recursive(&input[start + 1..i], true)?);
+            }
+        } else if level == 0 {
+            result.push(character);
+        }
+    }
+
+    if is_eval {
+        let expr = evalexpr::eval(&result)?.to_string();
+        input_changed = true;
+        result = expr;
+    }
+
+    if input_changed {
+        Ok(result.into())
+    } else {
+        Ok(input.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let result = eval("foo $(1+$(1+1)) after_foo");
+        assert_eq!(result.unwrap(), "foo 3 after_foo");
+    }
+    #[test]
+    fn nested_braces() {
+        let result = eval("$((0))");
+        assert_eq!(result.unwrap(), "0");
+    }
+    #[test]
+    fn basic_eval_max() {
+        let result = eval("$(max(1,2,3,4))");
+        assert_eq!(result.unwrap(), "4");
+    }
+    #[test]
+    fn basic_eval_add() {
+        let result = eval("$(str::to_uppercase \"foobar\")");
+        assert_eq!(result.unwrap(), "\"FOOBAR\"");
+    }
+    #[test]
+    fn unchanged() {
+        let result = eval("just some text");
+        assert_eq!(result.unwrap(), Cow::Borrowed("just some text"));
+    }
+    #[test]
+    fn escaped_dollar() {
+        let literal = "just some $$(foo) text";
+        let result = eval(literal);
+        assert_eq!(result.unwrap(), Cow::Borrowed(literal));
+    }
+}

--- a/src/nested_env/mod.rs
+++ b/src/nested_env/mod.rs
@@ -2,6 +2,7 @@ use im::{vector, HashMap, Vector};
 use itertools::join;
 
 mod expand;
+mod expr;
 
 pub use expand::{expand, IfMissing};
 

--- a/src/tests/31_expr/build_expected/build-global.ninja
+++ b/src/tests/31_expr/build_expected/build-global.ninja
@@ -1,0 +1,18 @@
+builddir = build
+build ALWAYS: phony
+rule CC_14556393563797253018
+  command = echo result = 2  ${in} > ${out}
+  description = CC
+
+build build/objects/single_app.7419491670495048065.o: $
+    CC_14556393563797253018 $
+    single_app.c
+
+rule LINK_5506617845631750009
+  command = cat ${in} > ${out}
+  description = LINK
+
+build build/single_builder/single_app/single_app.elf: $
+    LINK_5506617845631750009 $
+    build/objects/single_app.7419491670495048065.o
+

--- a/src/tests/31_expr/build_expected/objects/single_app.7419491670495048065.o
+++ b/src/tests/31_expr/build_expected/objects/single_app.7419491670495048065.o
@@ -1,0 +1,1 @@
+result = 2 single_app.c

--- a/src/tests/31_expr/build_expected/single_builder/single_app/single_app.elf
+++ b/src/tests/31_expr/build_expected/single_builder/single_app/single_app.elf
@@ -1,0 +1,1 @@
+result = 2 single_app.c

--- a/src/tests/31_expr/laze-project.yml
+++ b/src/tests/31_expr/laze-project.yml
@@ -1,0 +1,22 @@
+builders:
+  - name: single_builder
+    rules:
+        - name: CC
+          in: 'c'
+          out: 'o'
+          cmd: 'echo ${LOCAL_VAR} ${GLOBAL_VAR} ${in} > ${out}'
+        - name: LINK
+          in: 'o'
+          cmd: 'cat ${in} > ${out}'
+
+    env:
+      bindir: build/${builder}/${app}
+
+apps:
+  - name: single_app
+    sources:
+      - single_app.c
+
+    env:
+      local:
+        LOCAL_VAR: "result = $(1+1)"

--- a/src/tests/31_expr/single_app.c
+++ b/src/tests/31_expr/single_app.c
@@ -1,0 +1,1 @@
+content of single_app.c

--- a/src/tests/31_expr/test.sh
+++ b/src/tests/31_expr/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+. ../test-common.sh
+
+cleanup
+build
+clean_temp_files
+
+diff -r build build_expected
+
+echo TEST_OK
+
+cleanup


### PR DESCRIPTION
This PR adds basic expression evaluation using the [evalexpr](https://github.com/ISibboI/evalexpr) crate.

Any variable or task cmd may use `$(expression)` now.

Fixes #222.