### PR TITLE
feat: add post-link rule processing

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -742,13 +742,8 @@ fn configure_build(
             // create an alias (phony build entry) for "outs_${hash}" of this custom build.
             // that way, dependees don't have to list all the outs, but just
             // this alias
-            let outs_alias_output = Cow::from(Utf8PathBuf::from(format!("outs_{outs_hash}")));
-            let outs_alias = NinjaBuildBuilder::default()
-                .rule("phony")
-                .inputs(outs.clone())
-                .out(outs_alias_output)
-                .build()
-                .unwrap();
+            let outs_alias =
+                crate::ninja::alias_multiple(outs.clone(), &format!("outs_{outs_hash}"));
 
             // append our outs alias to this module's exported build deps
             module_build_dep_files

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -732,7 +732,7 @@ fn configure_build(
             // 4. render ninja "build:" snippet and add to this build's
             // ninja statement set
             let build = NinjaBuildBuilder::default()
-                .rule(&*rule.name)
+                .with_rule(&rule)
                 .inputs(sources)
                 .outs(outs.clone())
                 .deps(combined_build_deps)
@@ -831,7 +831,7 @@ fn configure_build(
                 // 4. render ninja "build:" snippet and add to this build's
                 // ninja statement set
                 let build = NinjaBuildBuilder::default()
-                    .rule(&*ninja_rule.name)
+                    .with_rule(&ninja_rule)
                     .input(Cow::from(srcpath.as_path()))
                     .deps(combined_build_deps.clone())
                     .out(object.as_path())

--- a/src/model/rule.rs
+++ b/src/model/rule.rs
@@ -67,6 +67,7 @@ impl<'a> From<&'a Rule> for crate::ninja::NinjaRuleBuilder<'a> {
             .rspfile(rule.rspfile.as_deref().map(Cow::from))
             .rspfile_content(rule.rspfile_content.as_deref().map(Cow::from))
             .pool(rule.pool.as_deref().map(Cow::from))
+            .always(rule.always)
             .deps(match &rule.gcc_deps {
                 None => NinjaRuleDeps::None,
                 Some(s) => NinjaRuleDeps::GCC(s.into()),

--- a/src/ninja/mod.rs
+++ b/src/ninja/mod.rs
@@ -346,6 +346,16 @@ pub fn alias<'a>(input: &'a str, alias: &'a str) -> String {
         .to_string()
 }
 
+pub fn alias_multiple<'a>(inputs: Vec<Cow<'a, Utf8Path>>, alias: &'a str) -> String {
+    NinjaBuildBuilder::default()
+        .rule("phony")
+        .inputs(inputs)
+        .out(Cow::from(Utf8Path::new(alias)))
+        .build()
+        .unwrap()
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ninja/mod.rs
+++ b/src/ninja/mod.rs
@@ -163,6 +163,10 @@ impl<'a> NinjaBuildBuilder<'a> {
         }
         self
     }
+
+    pub fn with_rule(&mut self, rule: &'a NinjaRule) -> &mut Self {
+        self.rule(&*rule.name).always(rule.always)
+    }
 }
 
 impl<'a> fmt::Display for NinjaBuild<'a> {


### PR DESCRIPTION
This can be used for e.g., produce a bootloader binary from a .elf.
As is, it is still clumsy to use. It'll probably be possible to define ~~"tasks"~~ rules in modules, at that point this will become more useful.