### PR TITLE
feat: import from command output

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -28,7 +28,7 @@ use crate::serde_bool_helpers::default_as_false;
 use crate::utils::StringOrMapVecString;
 
 mod import;
-use import::Import;
+use import::ImportEntry;
 
 pub type FileTreeState = TreeState<FileState, std::path::PathBuf>;
 
@@ -76,7 +76,7 @@ struct YamlFile {
     modules: Option<Option<Vec<YamlModule>>>,
     #[serde(default, deserialize_with = "deserialize_some")]
     apps: Option<Option<Vec<YamlModule>>>,
-    imports: Option<Vec<Import>>,
+    imports: Option<Vec<ImportEntry>>,
     subdirs: Option<Vec<String>>,
     defaults: Option<HashMap<String, YamlModule>>,
     #[serde(default, deserialize_with = "deserialize_version_checked")]

--- a/src/data/import.rs
+++ b/src/data/import.rs
@@ -10,15 +10,126 @@ use url::Url;
 use crate::download::{Download, Git, Source};
 use crate::utils::calculate_hash;
 
+mod cmd;
+
 #[derive(Debug, Serialize, Deserialize, Hash)]
 #[serde(untagged)]
-pub enum Import {
+pub enum ImportEntry {
     Download(Download),
+    Command(cmd::Command),
+}
+
+impl ImportEntry {
+    pub fn handle<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
+        match self {
+            Self::Download(download) => download.handle(build_dir),
+            Self::Command(command) => command.handle(build_dir),
+        }
+    }
 }
 
 #[derive(RustEmbed)]
 #[folder = "assets/imports"]
 struct Asset;
+
+pub trait Import: std::hash::Hash {
+    fn get_name(&self) -> Option<String>;
+    fn handle<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error>;
+    fn get_path<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
+        let source_hash = calculate_hash(&self);
+
+        let mut res = Utf8PathBuf::from(build_dir.as_ref());
+        res.push("imports");
+        if let Some(name) = self.get_name() {
+            res.push(format!("{name}-{source_hash}"));
+        } else {
+            res.push(format!("{source_hash}"));
+        }
+        Ok(res)
+    }
+}
+
+impl Import for Download {
+    fn handle<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
+        let path = self.get_path(build_dir).unwrap();
+        let tagfile = path.join(".laze-downloaded");
+
+        if !tagfile.exists() {
+            match &self.source {
+                Source::Git(Git::Commit { url, commit }) => {
+                    println!("IMPORT Git {url}:{commit} -> {path}");
+
+                    let status = if Url::parse(url).is_ok() {
+                        Command::new("git")
+                            .args(["cache", "clone", url, commit, path.as_str()])
+                            .status()?
+                    } else {
+                        let mut status = Command::new("git")
+                            .args(["clone", "--no-checkout", url, path.as_str()])
+                            .status()?;
+                        if status.success() {
+                            status = Command::new("git")
+                                .args(["-C", path.as_str(), "checkout", commit])
+                                .status()?;
+                        }
+                        status
+                    };
+
+                    if status.success() {
+                        File::create(tagfile)?;
+                    } else {
+                        return Err(anyhow!(
+                            "could not import from git url: {url} commit: {commit}",
+                        ));
+                    }
+                }
+                Source::Laze(name) => {
+                    let mut at_least_one = false;
+                    let prefix = format!("{name}/");
+                    for filename in Asset::iter().filter(|x| x.starts_with(&prefix)) {
+                        if !at_least_one {
+                            at_least_one = true;
+                            std::fs::create_dir_all(&path)
+                                .with_context(|| format!("creating {path}"))?;
+                        }
+
+                        let embedded_file = Asset::get(&filename).unwrap();
+                        let filename = filename.strip_prefix(&prefix).unwrap();
+                        let filename = path.join(filename);
+                        let parent = path.parent().unwrap();
+                        std::fs::create_dir_all(path.parent().unwrap())
+                            .with_context(|| format!("creating {parent}"))?;
+                        std::fs::write(&filename, embedded_file.data)
+                            .with_context(|| format!("creating {filename}"))?;
+                    }
+                    if at_least_one {
+                        File::create(&tagfile).with_context(|| format!("creating {tagfile}"))?;
+                    } else {
+                        return Err(anyhow!("could not import from laze defaults: {name}"));
+                    }
+                }
+            }
+        }
+
+        get_lazefile(&path)
+    }
+
+    fn get_name(&self) -> Option<String> {
+        match &self.source {
+            Source::Git(Git::Commit { url, .. }) => url.split('/').last().map(|x| x.to_string()),
+            Source::Laze(name) => {
+                let prefix = format!("{}/", name);
+
+                if Asset::iter().any(|x| x.starts_with(&prefix)) {
+                    let build_uuid_hash = calculate_hash(&build_uuid::get());
+                    Some(format!("laze/{name}-{build_uuid_hash}"))
+                } else {
+                    None
+                }
+            } //_ => None,
+        }
+    }
+}
 
 fn get_existing_file(path: &Utf8Path, filenames: &[&str]) -> Option<Utf8PathBuf> {
     for filename in filenames.iter() {
@@ -30,114 +141,8 @@ fn get_existing_file(path: &Utf8Path, filenames: &[&str]) -> Option<Utf8PathBuf>
     None
 }
 
-impl Import {
-    pub fn get_path<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
-        match self {
-            Import::Download(download) => {
-                let source_hash = calculate_hash(&download);
-
-                let mut res = Utf8PathBuf::from(build_dir.as_ref());
-                res.push("imports");
-                if let Some(name) = self.get_name() {
-                    res.push(format!("{name}-{source_hash}"));
-                } else {
-                    res.push(format!("{source_hash}"));
-                }
-                Ok(res)
-            }
-        }
-    }
-
-    pub fn handle<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
-        match self {
-            Import::Download(download) => {
-                let path = self.get_path(build_dir).unwrap();
-                let tagfile = path.join(".laze-downloaded");
-
-                if !tagfile.exists() {
-                    match &download.source {
-                        Source::Git(Git::Commit { url, commit }) => {
-                            println!("IMPORT Git {url}:{commit} -> {path}");
-
-                            let status = if Url::parse(url).is_ok() {
-                                Command::new("git")
-                                    .args(["cache", "clone", url, commit, path.as_str()])
-                                    .status()?
-                            } else {
-                                let mut status = Command::new("git")
-                                    .args(["clone", "--no-checkout", url, path.as_str()])
-                                    .status()?;
-                                if status.success() {
-                                    status = Command::new("git")
-                                        .args(["-C", path.as_str(), "checkout", commit])
-                                        .status()?;
-                                }
-                                status
-                            };
-
-                            if status.success() {
-                                File::create(tagfile)?;
-                            } else {
-                                return Err(anyhow!(
-                                    "could not import from git url: {url} commit: {commit}",
-                                ));
-                            }
-                        }
-                        Source::Laze(name) => {
-                            let mut at_least_one = false;
-                            let prefix = format!("{name}/");
-                            for filename in Asset::iter().filter(|x| x.starts_with(&prefix)) {
-                                if !at_least_one {
-                                    at_least_one = true;
-                                    std::fs::create_dir_all(&path)
-                                        .with_context(|| format!("creating {path}"))?;
-                                }
-
-                                let embedded_file = Asset::get(&filename).unwrap();
-                                let filename = filename.strip_prefix(&prefix).unwrap();
-                                let filename = path.join(filename);
-                                let parent = path.parent().unwrap();
-                                std::fs::create_dir_all(path.parent().unwrap())
-                                    .with_context(|| format!("creating {parent}"))?;
-                                std::fs::write(&filename, embedded_file.data)
-                                    .with_context(|| format!("creating {filename}"))?;
-                            }
-                            if at_least_one {
-                                File::create(&tagfile)
-                                    .with_context(|| format!("creating {tagfile}"))?;
-                            } else {
-                                return Err(anyhow!("could not import from laze defaults: {name}"));
-                            }
-                        }
-                    }
-                }
-
-                get_existing_file(&path, &["laze-lib.yml", "laze.yml", "laze-project.yml"]).ok_or(
-                    anyhow!("no \"laze-lib.yml\", \"laze.yml\" or \"laze-project.yml\" in import"),
-                )
-            }
-        }
-    }
-
-    pub fn get_name(&self) -> Option<String> {
-        match self {
-            Import::Download(download) => {
-                match &download.source {
-                    Source::Git(Git::Commit { url, .. }) => {
-                        url.split('/').last().map(|x| x.to_string())
-                    }
-                    Source::Laze(name) => {
-                        let prefix = format!("{}/", name);
-
-                        if Asset::iter().any(|x| x.starts_with(&prefix)) {
-                            let build_uuid_hash = calculate_hash(&build_uuid::get());
-                            Some(format!("laze/{name}-{build_uuid_hash}"))
-                        } else {
-                            None
-                        }
-                    } //_ => None,
-                }
-            }
-        }
-    }
+fn get_lazefile(path: &Utf8Path) -> Result<Utf8PathBuf, Error> {
+    get_existing_file(&path, &["laze-lib.yml", "laze.yml", "laze-project.yml"]).ok_or(anyhow!(
+        "no \"laze-lib.yml\", \"laze.yml\" or \"laze-project.yml\" in import"
+    ))
 }

--- a/src/data/import.rs
+++ b/src/data/import.rs
@@ -11,9 +11,9 @@ use crate::download::{Download, Git, Source};
 use crate::utils::calculate_hash;
 
 #[derive(Debug, Serialize, Deserialize, Hash)]
-pub struct Import {
-    #[serde(flatten)]
-    download: Download,
+#[serde(untagged)]
+pub enum Import {
+    Download(Download),
 }
 
 #[derive(RustEmbed)]
@@ -32,97 +32,112 @@ fn get_existing_file(path: &Utf8Path, filenames: &[&str]) -> Option<Utf8PathBuf>
 
 impl Import {
     pub fn get_path<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
-        let source_hash = calculate_hash(&self.download);
+        match self {
+            Import::Download(download) => {
+                let source_hash = calculate_hash(&download);
 
-        let mut res = Utf8PathBuf::from(build_dir.as_ref());
-        res.push("imports");
-        if let Some(name) = self.get_name() {
-            res.push(format!("{name}-{source_hash}"));
-        } else {
-            res.push(format!("{source_hash}"));
+                let mut res = Utf8PathBuf::from(build_dir.as_ref());
+                res.push("imports");
+                if let Some(name) = self.get_name() {
+                    res.push(format!("{name}-{source_hash}"));
+                } else {
+                    res.push(format!("{source_hash}"));
+                }
+                Ok(res)
+            }
         }
-        Ok(res)
     }
 
     pub fn handle<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
-        let path = self.get_path(build_dir).unwrap();
-        let tagfile = path.join(".laze-downloaded");
+        match self {
+            Import::Download(download) => {
+                let path = self.get_path(build_dir).unwrap();
+                let tagfile = path.join(".laze-downloaded");
 
-        if !tagfile.exists() {
-            match &self.download.source {
-                Source::Git(Git::Commit { url, commit }) => {
-                    println!("IMPORT Git {url}:{commit} -> {path}");
+                if !tagfile.exists() {
+                    match &download.source {
+                        Source::Git(Git::Commit { url, commit }) => {
+                            println!("IMPORT Git {url}:{commit} -> {path}");
 
-                    let status = if Url::parse(url).is_ok() {
-                        Command::new("git")
-                            .args(["cache", "clone", url, commit, path.as_str()])
-                            .status()?
-                    } else {
-                        let mut status = Command::new("git")
-                            .args(["clone", "--no-checkout", url, path.as_str()])
-                            .status()?;
-                        if status.success() {
-                            status = Command::new("git")
-                                .args(["-C", path.as_str(), "checkout", commit])
-                                .status()?;
+                            let status = if Url::parse(url).is_ok() {
+                                Command::new("git")
+                                    .args(["cache", "clone", url, commit, path.as_str()])
+                                    .status()?
+                            } else {
+                                let mut status = Command::new("git")
+                                    .args(["clone", "--no-checkout", url, path.as_str()])
+                                    .status()?;
+                                if status.success() {
+                                    status = Command::new("git")
+                                        .args(["-C", path.as_str(), "checkout", commit])
+                                        .status()?;
+                                }
+                                status
+                            };
+
+                            if status.success() {
+                                File::create(tagfile)?;
+                            } else {
+                                return Err(anyhow!(
+                                    "could not import from git url: {url} commit: {commit}",
+                                ));
+                            }
                         }
-                        status
-                    };
+                        Source::Laze(name) => {
+                            let mut at_least_one = false;
+                            let prefix = format!("{name}/");
+                            for filename in Asset::iter().filter(|x| x.starts_with(&prefix)) {
+                                if !at_least_one {
+                                    at_least_one = true;
+                                    std::fs::create_dir_all(&path)
+                                        .with_context(|| format!("creating {path}"))?;
+                                }
 
-                    if status.success() {
-                        File::create(tagfile)?;
-                    } else {
-                        return Err(anyhow!(
-                            "could not import from git url: {url} commit: {commit}",
-                        ));
+                                let embedded_file = Asset::get(&filename).unwrap();
+                                let filename = filename.strip_prefix(&prefix).unwrap();
+                                let filename = path.join(filename);
+                                let parent = path.parent().unwrap();
+                                std::fs::create_dir_all(path.parent().unwrap())
+                                    .with_context(|| format!("creating {parent}"))?;
+                                std::fs::write(&filename, embedded_file.data)
+                                    .with_context(|| format!("creating {filename}"))?;
+                            }
+                            if at_least_one {
+                                File::create(&tagfile)
+                                    .with_context(|| format!("creating {tagfile}"))?;
+                            } else {
+                                return Err(anyhow!("could not import from laze defaults: {name}"));
+                            }
+                        }
                     }
                 }
-                Source::Laze(name) => {
-                    let mut at_least_one = false;
-                    let prefix = format!("{name}/");
-                    for filename in Asset::iter().filter(|x| x.starts_with(&prefix)) {
-                        if !at_least_one {
-                            at_least_one = true;
-                            std::fs::create_dir_all(&path)
-                                .with_context(|| format!("creating {path}"))?;
-                        }
 
-                        let embedded_file = Asset::get(&filename).unwrap();
-                        let filename = filename.strip_prefix(&prefix).unwrap();
-                        let filename = path.join(filename);
-                        let parent = path.parent().unwrap();
-                        std::fs::create_dir_all(path.parent().unwrap())
-                            .with_context(|| format!("creating {parent}"))?;
-                        std::fs::write(&filename, embedded_file.data)
-                            .with_context(|| format!("creating {filename}"))?;
-                    }
-                    if at_least_one {
-                        File::create(&tagfile).with_context(|| format!("creating {tagfile}"))?;
-                    } else {
-                        return Err(anyhow!("could not import from laze defaults: {name}"));
-                    }
-                }
+                get_existing_file(&path, &["laze-lib.yml", "laze.yml", "laze-project.yml"]).ok_or(
+                    anyhow!("no \"laze-lib.yml\", \"laze.yml\" or \"laze-project.yml\" in import"),
+                )
             }
         }
-
-        get_existing_file(&path, &["laze-lib.yml", "laze.yml", "laze-project.yml"]).ok_or(anyhow!(
-            "no \"laze-lib.yml\", \"laze.yml\" or \"laze-project.yml\" in import"
-        ))
     }
 
     pub fn get_name(&self) -> Option<String> {
-        match &self.download.source {
-            Source::Git(Git::Commit { url, .. }) => url.split('/').last().map(|x| x.to_string()),
-            Source::Laze(name) => {
-                let prefix = format!("{}/", name);
+        match self {
+            Import::Download(download) => {
+                match &download.source {
+                    Source::Git(Git::Commit { url, .. }) => {
+                        url.split('/').last().map(|x| x.to_string())
+                    }
+                    Source::Laze(name) => {
+                        let prefix = format!("{}/", name);
 
-                if Asset::iter().any(|x| x.starts_with(&prefix)) {
-                    let build_uuid_hash = calculate_hash(&build_uuid::get());
-                    Some(format!("laze/{name}-{build_uuid_hash}"))
-                } else {
-                    None
+                        if Asset::iter().any(|x| x.starts_with(&prefix)) {
+                            let build_uuid_hash = calculate_hash(&build_uuid::get());
+                            Some(format!("laze/{name}-{build_uuid_hash}"))
+                        } else {
+                            None
+                        }
+                    } //_ => None,
                 }
-            } //_ => None,
+            }
         }
     }
 }

--- a/src/data/import/cmd.rs
+++ b/src/data/import/cmd.rs
@@ -1,0 +1,45 @@
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Hash)]
+pub struct Command {
+    pub name: Option<String>,
+    pub command: String,
+}
+
+impl super::Import for Command {
+    fn get_name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
+    fn handle<T: AsRef<camino::Utf8Path>>(
+        &self,
+        build_dir: T,
+    ) -> Result<camino::Utf8PathBuf, anyhow::Error> {
+        let path = self.get_path(&build_dir)?;
+
+        std::fs::create_dir_all(&path).with_context(|| format!("creating {path}"))?;
+
+        // Run the command
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&self.command)
+            .current_dir(&path)
+            .status()
+            .with_context(|| {
+                format!(
+                    "executing command \"{}\" in path \"{}\"",
+                    &self.command, &path
+                )
+            })?;
+
+        if !status.success() {
+            return Err(anyhow!(format!(
+                "executing command \"{}\" in path \"{}\" failed with exit code {}",
+                &self.command, &path, status
+            )));
+        }
+
+        super::get_lazefile(&path)
+    }
+}

--- a/src/data/import/download.rs
+++ b/src/data/import/download.rs
@@ -1,0 +1,98 @@
+use std::fs::File;
+use std::process::Command;
+
+use anyhow::{Context as _, Error};
+use camino::{Utf8Path, Utf8PathBuf};
+use rust_embed::RustEmbed;
+use url::Url;
+
+use super::Import;
+use crate::download::{Download, Git, Source};
+
+#[derive(RustEmbed)]
+#[folder = "assets/imports"]
+struct Asset;
+
+impl Import for Download {
+    fn handle<T: AsRef<Utf8Path>>(&self, build_dir: T) -> Result<Utf8PathBuf, Error> {
+        let path = self.get_path(build_dir).unwrap();
+        let tagfile = path.join(".laze-downloaded");
+
+        if !tagfile.exists() {
+            match &self.source {
+                Source::Git(Git::Commit { url, commit }) => {
+                    println!("IMPORT Git {url}:{commit} -> {path}");
+
+                    let status = if Url::parse(url).is_ok() {
+                        Command::new("git")
+                            .args(["cache", "clone", url, commit, path.as_str()])
+                            .status()?
+                    } else {
+                        let mut status = Command::new("git")
+                            .args(["clone", "--no-checkout", url, path.as_str()])
+                            .status()?;
+                        if status.success() {
+                            status = Command::new("git")
+                                .args(["-C", path.as_str(), "checkout", commit])
+                                .status()?;
+                        }
+                        status
+                    };
+
+                    if status.success() {
+                        File::create(tagfile)?;
+                    } else {
+                        return Err(anyhow!(
+                            "could not import from git url: {url} commit: {commit}",
+                        ));
+                    }
+                }
+                Source::Laze(name) => {
+                    let mut at_least_one = false;
+                    let prefix = format!("{name}/");
+                    for filename in Asset::iter().filter(|x| x.starts_with(&prefix)) {
+                        if !at_least_one {
+                            at_least_one = true;
+                            std::fs::create_dir_all(&path)
+                                .with_context(|| format!("creating {path}"))?;
+                        }
+
+                        let embedded_file = Asset::get(&filename).unwrap();
+                        let filename = filename.strip_prefix(&prefix).unwrap();
+                        let filename = path.join(filename);
+                        let parent = path.parent().unwrap();
+                        std::fs::create_dir_all(path.parent().unwrap())
+                            .with_context(|| format!("creating {parent}"))?;
+                        std::fs::write(&filename, embedded_file.data)
+                            .with_context(|| format!("creating {filename}"))?;
+                    }
+                    if at_least_one {
+                        File::create(&tagfile).with_context(|| format!("creating {tagfile}"))?;
+                    } else {
+                        return Err(anyhow!("could not import from laze defaults: {name}"));
+                    }
+                }
+            }
+        }
+
+        super::get_lazefile(&path)
+    }
+
+    fn get_name(&self) -> Option<String> {
+        use crate::utils::calculate_hash;
+
+        match &self.source {
+            Source::Git(Git::Commit { url, .. }) => url.split('/').last().map(|x| x.to_string()),
+            Source::Laze(name) => {
+                let prefix = format!("{}/", name);
+
+                if Asset::iter().any(|x| x.starts_with(&prefix)) {
+                    let build_uuid_hash = calculate_hash(&build_uuid::get());
+                    Some(format!("laze/{name}-{build_uuid_hash}"))
+                } else {
+                    None
+                }
+            } //_ => None,
+        }
+    }
+}

--- a/src/nested_env/mod.rs
+++ b/src/nested_env/mod.rs
@@ -16,7 +16,7 @@ pub struct Env {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
-#[serde(untagged)]
+#[serde(untagged, expecting = "expected single value or array of values")]
 pub enum EnvKey {
     Single(String),
     List(Vector<String>),


### PR DESCRIPTION
This PR adds initial support for creating laze files on-the-fly by calling a command.

Use cases would be

- create modules setting variables via shell script
- parse e.g., Cargo workspace, and create applications from it
- parse pkgconf database, create modules from it on-the-fly

This initial implementation is *very* basic. E.g., it will only but always re-run whenever any laze file is out of date. No caching or other control. Baby steps. :)