### PR TITLE
fix: task exports broke caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- fix buildfile caching (was broken by task `export`)
+
 ## [0.1.25] - 2024-11-25
 
 ### Added

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,3 +13,4 @@ pub use dependency::Dependency;
 pub use module::{CustomBuild, Module};
 pub use rule::Rule;
 pub use task::Task;
+pub use task::VarExportSpec;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,8 @@ use std::hash::{Hash, Hasher};
 use camino::Utf8PathBuf;
 use indexmap::IndexMap;
 
+use crate::model::VarExportSpec;
+
 pub(crate) fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
     t.hash(&mut s);
@@ -22,6 +24,24 @@ pub enum StringOrMapVecString {
 pub enum StringOrMapString {
     String(String),
     Map(std::collections::HashMap<String, String>),
+}
+
+impl From<StringOrMapString> for crate::model::VarExportSpec {
+    fn from(value: StringOrMapString) -> Self {
+        match value {
+            StringOrMapString::String(s) => VarExportSpec {
+                variable: s,
+                content: None,
+            },
+            StringOrMapString::Map(mut m) => {
+                let (k, v) = m.drain().last().unwrap();
+                VarExportSpec {
+                    variable: k,
+                    content: Some(v),
+                }
+            }
+        }
+    }
 }
 
 pub(crate) trait ContainingPath<T: AsRef<std::path::Path>> {


### PR DESCRIPTION
This was broken by adding task `exports`, which used untagged enums, which bincode cannot support b/c it is not self-describing, ...