### PR TITLE
fix: split build_uuid handling out of GenerateResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix cache laze version check
 - fix buildfile caching (was broken by task `export`)
 
 ## [0.1.25] - 2024-11-25


### PR DESCRIPTION
This fixes a potential crash when trying to read a cache from a different version.