### PR TITLE
fix `$root` default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix `$root` to contain `.` (as documented)
 - fix cache laze version check
 - fix buildfile caching (was broken by task `export`)
 

--- a/book/src/reference/variables.md
+++ b/book/src/reference/variables.md
@@ -62,7 +62,7 @@ modules:
 
 This variable will be replaced with the relative path to the root of the main
 project. This can be used for specifying root-relative path names.
-Usually (for laze projects that were not imported), this contains `./`
+Usually (for laze projects that were not imported), this contains `.`
 If a laze file is part of an import of another laze project, `${root}` contains
 the relative path to the location where the import has been downloaded.
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -149,6 +149,7 @@ impl Generator {
         laze_env.insert("build-dir".to_string(), self.build_dir.clone());
         laze_env.insert("outfile".to_string(), "${bindir}/${app}.elf");
         laze_env.insert("project-root".to_string(), self.project_root.clone());
+        laze_env.insert("root".to_string(), ".");
 
         // make our binary path available, used by e.g., the default download rules.
         laze_env.insert(

--- a/src/tests/40_import_root_cwd/build_expected/build-global.ninja
+++ b/src/tests/40_import_root_cwd/build_expected/build-global.ninja
@@ -8,11 +8,11 @@ build build/objects/foo.10053017565851818003.o: $
     CC_12898610496162985655 $
     foo.c
 
-rule LINK_17967468300177441195
-  command = echo LINK ${out} root= relpath=. relroot= > ${out} && cat ${in} >> ${out}
+rule LINK_3520720391709292017
+  command = echo LINK ${out} root=. relpath=. relroot=. > ${out} && cat ${in} >> ${out}
   description = LINK
 
 build build/single_builder/app/app.elf: $
-    LINK_17967468300177441195 $
+    LINK_3520720391709292017 $
     build/objects/foo.10053017565851818003.o
 

--- a/src/tests/40_import_root_cwd/build_expected/single_builder/app/app.elf
+++ b/src/tests/40_import_root_cwd/build_expected/single_builder/app/app.elf
@@ -1,2 +1,2 @@
-LINK build/single_builder/app/app.elf root= relpath=. relroot=
+LINK build/single_builder/app/app.elf root=. relpath=. relroot=.
 CC foo.c root=. relpath=. relroot=. LOCAL_RELPATH=.


### PR DESCRIPTION
Was emtpy for non-imports, should be `.`