### PR TITLE
feat: rules `export` shell exports

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use super::{ninja::NinjaBuildBuilder, Module, Rule};
-use crate::nested_env::{self, IfMissing};
 use camino::{Utf8Path, Utf8PathBuf};
 
 pub mod source {
@@ -101,9 +100,7 @@ impl Download {
             None => panic!("missing {} rule for module {}", rulename, module.name),
         };
 
-        let expanded = nested_env::expand_eval(&download_rule.cmd, env, IfMissing::Ignore)?;
-
-        let ninja_download_rule = download_rule.to_ninja().command(expanded).build().unwrap();
+        let ninja_download_rule = download_rule.to_ninja(env).unwrap();
 
         // "srcdir" is filled in data.rs
         let srcdir = module.srcdir.as_ref().unwrap();
@@ -145,9 +142,7 @@ impl Download {
             None => panic!("missing {} rule for module {}", rulename, module.name),
         };
 
-        let expanded = nested_env::expand_eval(&patch_rule.cmd, env, IfMissing::Ignore).unwrap();
-
-        let ninja_patch_rule = patch_rule.to_ninja().command(expanded).build().unwrap();
+        let ninja_patch_rule = patch_rule.to_ninja(env).unwrap();
 
         // "srcdir" is filled in data.rs
         let srcdir = module.srcdir.as_ref().unwrap();

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,6 +4,7 @@ mod context_bag;
 mod dependency;
 mod module;
 mod rule;
+mod shared;
 mod task;
 
 pub use blockallow::BlockAllow;
@@ -12,4 +13,5 @@ pub use context_bag::{ContextBag, IsAncestor};
 pub use dependency::Dependency;
 pub use module::{CustomBuild, Module};
 pub use rule::Rule;
-pub use task::{Task, TaskError, VarExportSpec};
+pub use shared::VarExportSpec;
+pub use task::{Task, TaskError};

--- a/src/model/shared.rs
+++ b/src/model/shared.rs
@@ -1,0 +1,45 @@
+use crate::nested_env;
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct VarExportSpec {
+    pub variable: String,
+    pub content: Option<String>,
+}
+
+impl VarExportSpec {
+    pub fn apply_env(&self, env: &im::HashMap<&String, String>) -> Self {
+        let content = if let Some(content) = self.content.as_ref() {
+            content.clone()
+        } else {
+            format!("${{{}}}", self.variable)
+        };
+
+        let content =
+            Some(nested_env::expand_eval(content, env, nested_env::IfMissing::Empty).unwrap());
+
+        Self {
+            variable: self.variable.clone(),
+            content,
+        }
+    }
+
+    pub(crate) fn expand(
+        export: Option<&Vec<VarExportSpec>>,
+        env: &im::HashMap<&String, String>,
+    ) -> Option<Vec<VarExportSpec>> {
+        // what this does is, apply the env to the format as given by "export:"
+        //
+        // e.g., assuming `FOO=value` and FOOBAR=`other_value`:
+        // ```yaml
+        //
+        // export:
+        //   - FOO
+        //   - BAR: bar
+        //   - FOOBAR: ${foobar}
+        // ```
+        //
+        // ... to export `FOO=value`, `BAR=bar` and `FOOBAR=other_value`.
+
+        export.map(|exports| exports.iter().map(|entry| entry.apply_env(env)).collect())
+    }
+}

--- a/src/ninja/mod.rs
+++ b/src/ninja/mod.rs
@@ -25,8 +25,6 @@ pub struct NinjaRule<'a> {
     pub name: Cow<'a, str>,
     command: Cow<'a, str>,
     description: Option<Cow<'a, str>>,
-    #[builder(setter(strip_option), default = "None")]
-    env: Option<&'a im::HashMap<&'a String, String>>,
     #[builder(default = "None")]
     export: Option<&'a Vec<VarExportSpec>>,
     #[builder(default = "NinjaRuleDeps::None")]
@@ -100,8 +98,25 @@ impl<'a> NinjaRule<'a> {
     }
 
     pub(crate) fn expand(mut self, env: &im::HashMap<&String, String>) -> anyhow::Result<Self> {
-        let expanded = nested_env::expand_eval(&self.command, env, IfMissing::Empty).unwrap();
-        self.command = expanded.into();
+        let mut command = String::with_capacity(self.command.len());
+
+        // handle "export" statements
+        let export = VarExportSpec::expand(self.export, env);
+        if let Some(export) = &export {
+            for entry in export {
+                let VarExportSpec { variable, content } = entry;
+                if let Some(val) = content {
+                    command.push_str(variable);
+                    command.push_str("=\"");
+                    command.push_str(val);
+                    command.push_str("\" && ");
+                }
+            }
+        }
+
+        let expanded = nested_env::expand_eval(&self.command, env, IfMissing::Empty)?;
+        command.push_str(&expanded);
+        self.command = command.into();
         Ok(self)
     }
 }

--- a/src/ninja/mod.rs
+++ b/src/ninja/mod.rs
@@ -9,6 +9,9 @@ use std::process::{Command, ExitStatus, Stdio};
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
 
+use crate::model::VarExportSpec;
+use crate::nested_env::{self, IfMissing};
+
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub enum NinjaRuleDeps {
     #[default]
@@ -16,14 +19,16 @@ pub enum NinjaRuleDeps {
     GCC(String),
 }
 
-#[derive(Builder, Debug, PartialEq, Eq, Clone)]
+#[derive(Builder, Clone)]
 #[builder(setter(into))]
 pub struct NinjaRule<'a> {
     pub name: Cow<'a, str>,
     command: Cow<'a, str>,
     description: Option<Cow<'a, str>>,
-    #[builder(setter(into, strip_option), default = "None")]
-    env: Option<&'a IndexMap<String, String>>,
+    #[builder(setter(strip_option), default = "None")]
+    env: Option<&'a im::HashMap<&'a String, String>>,
+    #[builder(default = "None")]
+    export: Option<&'a Vec<VarExportSpec>>,
     #[builder(default = "NinjaRuleDeps::None")]
     deps: NinjaRuleDeps,
     #[builder(default = "None")]
@@ -92,6 +97,12 @@ impl<'a> NinjaRule<'a> {
         let name = self.get_hashed_name(self.get_hash(None));
         self.name = Cow::from(name);
         self
+    }
+
+    pub(crate) fn expand(mut self, env: &im::HashMap<&String, String>) -> anyhow::Result<Self> {
+        let expanded = nested_env::expand_eval(&self.command, env, IfMissing::Empty).unwrap();
+        self.command = expanded.into();
+        Ok(self)
     }
 }
 


### PR DESCRIPTION
Allow rules to `export` to its command's shell environment.