### PR TITLE
feat!: implement must_provide

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: clone RIOT
       run: >
-        git clone --depth 1 https://github.com/kaspar030/RIOT -b add_laze_buildfiles_bencher
+        git clone --depth 1 https://github.com/kaspar030/RIOT -b add_laze_buildfiles_bencher_laze0.2
 
     - name: "Run benchmark"
       run: perf stat -j -o perf-stat.json -- laze -C RIOT build --global -G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `provides` / `provides_unique` now adds a hard dependency on a module with that
+  name
+- added `module::must_provide` indicating that a module cannot be selected directly
+
 ## [0.1.33] - 2025-02-24
 
 ### Added

--- a/src/build.rs
+++ b/src/build.rs
@@ -164,6 +164,10 @@ impl<'a> Resolver<'a> {
                 // all provided modules get added to the "provided_by" map, so later
                 // dependees of one of those get informed.
                 self.add_provided_by(name, module);
+
+                // here we add a hard dependency on any "provided" module,
+                // unless it starts with "::". (those are laze virtual modules, like,
+                // "::task::<taskname>").
                 if !name.starts_with("::") {
                     provided.push(Dependency::Hard(name.clone()));
                 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -181,6 +181,8 @@ struct YamlModule {
     is_global_build_dep: bool,
     #[serde(skip)]
     _is_binary: bool,
+    #[serde(default = "default_as_false")]
+    must_provide: bool,
     #[serde(rename = "meta")]
     _meta: Option<Value>,
 }
@@ -885,6 +887,8 @@ pub fn load(
             m.env_global
                 .insert("appdir".into(), EnvKey::Single(relpath.to_string()));
         }
+
+        m.must_provide = module.must_provide;
 
         Ok(m)
     }

--- a/src/model/module.rs
+++ b/src/model/module.rs
@@ -51,6 +51,7 @@ pub struct Module {
     pub is_build_dep: bool,
     pub is_global_build_dep: bool,
     pub is_binary: bool,
+    pub must_provide: bool,
 }
 
 impl Module {
@@ -84,6 +85,7 @@ impl Module {
             blocklist: None,
             allowlist: None,
             download: None,
+            must_provide: false,
         }
     }
 

--- a/src/tests/28_provides/build_expected/build-global.ninja
+++ b/src/tests/28_provides/build_expected/build-global.ninja
@@ -52,6 +52,6 @@ build build/upper2/app1/app1.elf: $
     LINK_5506617845631750009 $
     build/objects/app.12070292612711521013.o $
     build/objects/module.5640092437665481209.o $
-    build/objects/module.11691236658213220858.o $
-    build/objects/module.17680204663769875419.o
+    build/objects/module.17680204663769875419.o $
+    build/objects/module.11691236658213220858.o
 

--- a/src/tests/28_provides/build_expected/upper2/app1/app1.elf
+++ b/src/tests/28_provides/build_expected/upper2/app1/app1.elf
@@ -1,4 +1,4 @@
 app.c
 first_module module.c
-third_module module.c
 provided_module_from_upper2 module.c
+third_module module.c

--- a/src/tests/28_provides/laze-project.yml
+++ b/src/tests/28_provides/laze-project.yml
@@ -10,6 +10,10 @@ builders:
         cmd: "cat ${in} > ${out}"
     env:
       bindir: build/${builder}/${app}
+    tasks:
+      info-modules:
+        cmd:
+          - echo ${modules}
 
   - name: upper
     parent: default
@@ -69,6 +73,9 @@ modules:
       local:
         VAR:
           - provided_module_from_upper2
+
+  - name: provided
+    must_provide: true
 
 apps:
   - name: app1

--- a/src/tests/47_context_provides/laze-project.yml
+++ b/src/tests/47_context_provides/laze-project.yml
@@ -10,6 +10,10 @@ builders:
         cmd: "cat ${in} > ${out}"
     env:
       bindir: build/${builder}/${app}
+    tasks:
+      modules:
+        cmd:
+          - echo ${modules}
 
   - name: context1
     parent: default
@@ -40,6 +44,12 @@ builders:
     parent: context2
     provides_unique:
       - provided_by_context2
+
+modules:
+  - name: provided_by_context1
+    must_provide: true
+  - name: provided_by_context2
+    must_provide: true
 
 apps:
   - name: app1


### PR DESCRIPTION
This is an experimental draft making it possible to add a hard dependency (and `help`) to all providers of a provided name, by 

a) making a module with the provided name a hard dependency for all providers
b) allowing modules to specify `must_provide`, which makes them unavailable for `regular` select.

The help aspect of this can be achieved by adding a non-resolving select to a module with the provided name.