### PR TITLE
Option function: Do not add hash value to the object file path.

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -861,11 +861,14 @@ fn configure_build(
                 let rule_hash = ninja_rule.get_hash(None);
 
                 // 3. determine output path (e.g., name of C object file)
-                let out = srcpath.with_extension(format!(
-                    "{}.{}",
-                    rule_hash ^ build_deps_hash,
-                    &rule.out.as_ref().unwrap()
-                ));
+                let out_ext = {
+                    let raw_ext = rule.out.as_ref().unwrap();
+                    match rule.options.as_ref().and_then(|opts| opts.get("out_ext")) {
+                        Some(value) if value == "raw" => format!("{}", raw_ext),
+                        _ => format!("{}.{}", rule_hash ^ build_deps_hash, raw_ext),
+                    }
+                };
+                let out = srcpath.with_extension(out_ext);
 
                 let mut object = objdir.clone();
                 object.push(out);


### PR DESCRIPTION
Add the option `out_ext: raw` to the `rules`'s `options` to control not adding the hash value to the object file path.
```yaml
rules:
  - name: CC
    description: CC ${out}
    in: "c"
    out: "obj"
    options:
      out_ext: raw