### PR TITLE
feat: make output sharing optional

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -41,6 +41,7 @@
       - [rspfile_content](./reference/context/rule/rspfile_content.md)
       - [pool](./reference/context/rule/pool.md)
       - [always](./reference/context/rule/always.md)
+      - [shareable](./reference/context/rule/shareable.md)
     - [tasks]()
       - [cmd]()
       - [build]()

--- a/book/src/reference/context/rule/shareable.md
+++ b/book/src/reference/context/rule/shareable.md
@@ -1,0 +1,32 @@
+# shareable
+
+This boolean flag controls output sharing. It defaults to `true`.
+See [object sharing][object-sharing] for details.
+
+When enabled for a rule, this rule's output files will end up in a location
+that is context-independent:
+
+    ${build-dir}/objects/<filestem>.<hash>.<ext>
+
+E.g., a source file `some-module/foo.c` would end up in `${build-dir}/objects/some-module/foo.<hash>.o`.
+
+When disabled, the output will end up in a builder and app specific location:
+
+    ${bindir}/<file-path>/foo.o
+
+The variable `${bindir}` defaults to `${build-dir}/out/${builder}/${app}`, so
+e.g., a source file `some-module/foo.c` built for builder `host` and app `bar`
+would end up in `${bindir}/out/host/bar/some-module/foo.o`.
+
+Example:
+
+```yaml
+context:
+ - # ...
+   rules:
+   - name: MYRULE
+     shareable: false # disable object sharing for this rule
+   # ... possible other fields
+```
+
+[object-sharing]: ../../../concepts/object_sharing.md

--- a/book/src/reference/context/rules.md
+++ b/book/src/reference/context/rules.md
@@ -29,3 +29,4 @@ contexts:
 - [`rspfile_content`](./rule/rspfile_content.md)
 - [`pool`](./rule/pool.md)
 - [`always`](./rule/always.md)
+- [`shareable`](./rule/shareable.md)

--- a/src/data.rs
+++ b/src/data.rs
@@ -233,6 +233,9 @@ pub struct YamlRule {
     #[serde(default = "default_as_false")]
     pub always: bool,
 
+    #[serde(default = "default_as_true", alias = "sharable")]
+    pub shareable: bool,
+
     #[serde(rename = "meta")]
     _meta: Option<Value>,
 }
@@ -253,6 +256,7 @@ impl From<YamlRule> for Rule {
             gcc_deps: yaml_rule.gcc_deps,
             rspfile: yaml_rule.rspfile,
             rspfile_content: yaml_rule.rspfile_content,
+            shareable: yaml_rule.shareable,
             pool: yaml_rule.pool,
             description: yaml_rule.description,
             export: yaml_rule

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -866,13 +866,23 @@ fn configure_build(
                 let rule_hash = ninja_rule.get_hash(None);
 
                 // 3. determine output path (e.g., name of C object file)
-                let out = srcpath.with_extension(format!(
-                    "{}.{}",
-                    rule_hash ^ build_deps_hash,
-                    &rule.out.as_ref().unwrap()
-                ));
+                let out_ext = if rule.shareable {
+                    &format!(
+                        "{}.{}",
+                        rule_hash ^ build_deps_hash,
+                        &rule.out.as_ref().unwrap()
+                    )
+                } else {
+                    rule.out.as_ref().unwrap()
+                };
+
+                let out = srcpath.with_extension(out_ext);
 
                 let mut object = objdir.clone();
+                if !rule.shareable {
+                    object.push(&builder.name);
+                    object.push(&binary.name);
+                }
                 object.push(out);
 
                 // 4. render ninja "build:" snippet and add to this build's

--- a/src/model/rule.rs
+++ b/src/model/rule.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
-use crate::serde_bool_helpers::default_as_false;
+use crate::serde_bool_helpers::{default_as_false, default_as_true};
 
 #[derive(Debug, Serialize, Deserialize, Eq, Clone)]
 #[serde(deny_unknown_fields)]
@@ -29,6 +29,8 @@ pub struct Rule {
 
     #[serde(default = "default_as_false")]
     pub always: bool,
+    #[serde(default = "default_as_true")]
+    pub shareable: bool,
 }
 
 impl Rule {


### PR DESCRIPTION
This adds `shared_output: true|false` to `rules`. Defaults to `true`. When set to false,

1. doesn't add the rule hash to the filename
2. adds `${builder}/${binary}` to the output path to avoid clashes.

```
rules:
  - name: CC
    description: CC ${out}
    in: "c"
    out: "obj"
    shared_output: false
```