### PR TITLE
feat(tasks): pass extra task args as shell args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "shell-words",
  "shellexpand",
  "signal-hook",
  "solvent",
@@ -1478,12 +1477,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shellexpand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ rayon = "1.10.0"
 serde = "1.0.219"
 serde_derive = "1.0.219"
 serde_yaml = "0.9.34"
-shell-words = "1.1.0"
 treestate = "0.1.1"
 im = { version = "15.1.0", features = ["rayon", "serde"] }
 signal-hook = "0.3.17"

--- a/src/model/task.rs
+++ b/src/model/task.rs
@@ -46,8 +46,13 @@ impl Task {
         args: Option<&Vec<&str>>,
         verbose: u8,
     ) -> Result<(), Error> {
+        if verbose > 0 {
+            if let Some(args) = args {
+                println!("laze: ... with args: {args:?}");
+            }
+        }
+
         for cmd in &self.cmd {
-            use shell_words::join;
             use std::process::Command;
 
             let mut command = if cfg!(target_family = "windows") {
@@ -79,11 +84,7 @@ impl Task {
                 }
             }
 
-            if let Some(args) = args {
-                command.arg(cmd.clone() + " " + &join(args).to_owned());
-            } else {
-                command.arg(cmd);
-            }
+            command.arg(cmd);
 
             if verbose > 0 {
                 let command_with_args = command
@@ -93,6 +94,11 @@ impl Task {
                     .collect_vec();
 
                 println!("laze: executing `{}`", command_with_args.join(" "));
+            }
+
+            if let Some(args) = args {
+                command.arg("--");
+                command.args(args);
             }
 
             if self.ignore_ctrl_c {

--- a/src/tests/16_tasks/laze-project.yml
+++ b/src/tests/16_tasks/laze-project.yml
@@ -1,9 +1,9 @@
 builders:
   - name: default
     rules:
-        - name: LINK
-          in: 'o'
-          cmd: 'cat ${in} > ${out}'
+      - name: LINK
+        in: "o"
+        cmd: "cat ${in} > ${out}"
 
     env:
       bindir: build/${builder}/${app}
@@ -11,7 +11,7 @@ builders:
     tasks:
       echo:
         cmd:
-          - echo
+          - echo $*
       foobar:
         cmd:
           - echo -n foo


### PR DESCRIPTION
Previously, all extra args given to tasks were passed on as is, to each command of a task.

This PR makes this a bit more explicit - by passing the extra arg vector to the shells executing the tasks, as extra arguments.
So `sh -c "command" -- arg1 arg2` now, `sh -c "command arg1 arg2"` before.

This enables finer-grained control, especially for tasks consisting of multiple commands.

For any task to get back the previous (undocumented) behavior, append `$@` to each task's command.