### PR TITLE
task: Add args to builder before debug-printing arguments

### DIFF
--- a/src/model/task.rs
+++ b/src/model/task.rs
@@ -86,6 +86,11 @@ impl Task {
 
             command.arg(cmd);
 
+            if let Some(args) = args {
+                command.arg("--");
+                command.args(args);
+            }
+
             if verbose > 0 {
                 let command_with_args = command
                     .get_args()
@@ -94,11 +99,6 @@ impl Task {
                     .collect_vec();
 
                 println!("laze: executing `{}`", command_with_args.join(" "));
-            }
-
-            if let Some(args) = args {
-                command.arg("--");
-                command.args(args);
             }
 
             if self.ignore_ctrl_c {


### PR DESCRIPTION
It's very confusing now trying `laze build -s nightly -d stable -b nrf52840dk -v -d defmt bloat --help` and seeing:

```
laze: executing task bloat for builder nrf52840dk bin example-coap-server
laze: ... with args: ["--help"]
laze: executing ` OPENOCD_ARGS="-f board/nordic_nrf52_dk.cfg" [...]  cargo +nightly-2025-02-25 --config ../.././ariel-os-cargo.toml bloat --release --features=[...],ariel-os/coap-server `
```

Now it shows the added `-- --help` after one too many `--`, but at least it shows it.