### PR TITLE
feat(tasks): implement tasks calling subtasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,9 +1036,11 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "shellexpand",
  "signal-hook",
  "solvent",
+ "subst",
  "task_partitioner",
  "tempfile",
  "thiserror 2.0.12",
@@ -1479,6 +1481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shellexpand"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1562,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subst"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e7942675ea19db01ef8cf15a1e6443007208e6c74568bd64162da26d40160d"
+dependencies = [
+ "memchr",
+ "unicode-width",
+]
 
 [[package]]
 name = "syn"
@@ -1723,6 +1741,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ git-cache = "0.2.5"
 shellexpand = "3.1.1"
 thiserror = "2.0.12"
 im-rc = "15.1.0"
+shell-words = "1.1.0"
+subst = "0.3.7"
 
 [profile.release]
 lto = "fat"

--- a/src/data.rs
+++ b/src/data.rs
@@ -292,7 +292,7 @@ impl From<YamlTask> for Task {
             required_modules: yaml_task.required_modules,
             export: yaml_task
                 .export
-                .map(|s| s.iter().map(|s| s.clone().into()).collect_vec()),
+                .map(|s| s.iter().map(|s| s.clone().into()).collect()),
             build: yaml_task.build,
             ignore_ctrl_c: yaml_task.ignore_ctrl_c,
             workdir: yaml_task.workdir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod nested_env;
 mod new;
 mod ninja;
 mod serde_bool_helpers;
+mod subst_ext;
 mod task_runner;
 mod utils;
 
@@ -427,6 +428,12 @@ fn try_main() -> Result<i32> {
                                 "laze: task \"{task_name}\" on app \"{}\" for builder \"{}\"",
                                 result.build.binary, result.build.builder
                             );
+                        }
+                    } else {
+                        // only one error. can't move out of first, cant clone, so print that here.
+                        let (first, _rest) = results.split_first().unwrap();
+                        if let Err(e) = &first.result {
+                            eprintln!("laze: error: {e:#}");
                         }
                     }
                     return Ok(1);

--- a/src/model/shared.rs
+++ b/src/model/shared.rs
@@ -25,10 +25,14 @@ impl VarExportSpec {
         }
     }
 
-    pub(crate) fn expand(
-        export: Option<&Vec<VarExportSpec>>,
+    pub(crate) fn expand<
+        'a,
+        T: Iterator<Item = &'a VarExportSpec>,
+        U: FromIterator<VarExportSpec>,
+    >(
+        export: T,
         env: &im::HashMap<&String, String>,
-    ) -> Option<Vec<VarExportSpec>> {
+    ) -> U {
         // what this does is, apply the env to the format as given by "export:"
         //
         // e.g., assuming `FOO=value` and FOOBAR=`other_value`:
@@ -42,6 +46,6 @@ impl VarExportSpec {
         //
         // ... to export `FOO=value`, `BAR=bar` and `FOOBAR=other_value`.
 
-        export.map(|exports| exports.iter().map(|entry| entry.apply_env(env)).collect())
+        export.map(|entry| entry.apply_env(env)).collect()
     }
 }

--- a/src/subst_ext.rs
+++ b/src/subst_ext.rs
@@ -1,0 +1,51 @@
+use std::borrow::Cow;
+
+pub use subst::{substitute, VariableMap};
+
+pub struct LocalVec<'a, T>(&'a Vec<T>);
+
+impl<'a, T> LocalVec<'a, T> {
+    pub fn new(vec: &'a Vec<T>) -> Self {
+        Self(vec)
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+}
+
+impl<'a, T: AsRef<str>> VariableMap<'a> for LocalVec<'a, T> {
+    type Value = Cow<'a, str>;
+
+    #[inline]
+    fn get(&'a self, key: &str) -> Option<Self::Value> {
+        str::parse::<usize>(key)
+            .ok()
+            .filter(|index| *index > 0)
+            .filter(|index| *index <= self.0.len())
+            .map(|index| &self.as_slice()[index - 1])
+            .map(|s| Cow::from(s.as_ref()))
+    }
+}
+
+#[derive(Debug)]
+pub struct IgnoreMissing<'a, V, T: VariableMap<'a, Value = V>> {
+    inner: &'a T,
+}
+
+impl<'a, V, T: VariableMap<'a, Value = V>> IgnoreMissing<'a, V, T> {
+    pub fn new(inner: &'a T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, V, T: VariableMap<'a, Value = V>> VariableMap<'a> for IgnoreMissing<'a, V, T>
+where
+    V: AsRef<str> + Default,
+{
+    type Value = V;
+
+    fn get(&'a self, key: &str) -> Option<Self::Value> {
+        self.inner.get(key).or_else(|| Some(V::default()))
+    }
+}

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -37,7 +37,8 @@ where
 
         let all_tasks = &build.tasks;
 
-        let result = task.execute(project_root, args, verbose, all_tasks);
+        let parent_export = im::Vector::new();
+        let result = task.execute(project_root, args, verbose, all_tasks, &parent_export);
         let is_error = result.is_err();
 
         results.push(RunTaskResult {

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -35,7 +35,9 @@ where
             );
         }
 
-        let result = task.execute(project_root, args, verbose);
+        let all_tasks = &build.tasks;
+
+        let result = task.execute(project_root, args, verbose, all_tasks);
         let is_error = result.is_err();
 
         results.push(RunTaskResult {

--- a/src/tests/48_tasks_calling_tasks/EXPECTED_STDOUT_TAIL
+++ b/src/tests/48_tasks_calling_tasks/EXPECTED_STDOUT_TAIL
@@ -1,4 +1,3 @@
-laze: executing task echo-all for builder default bin app
 1: first=1
 1: second=2
 1: third=3
@@ -10,3 +9,5 @@ laze: executing task echo-all for builder default bin app
 4: 3
 5: 4
 1: first=any=first
+foo
+foo bar

--- a/src/tests/48_tasks_calling_tasks/EXPECTED_STDOUT_TAIL
+++ b/src/tests/48_tasks_calling_tasks/EXPECTED_STDOUT_TAIL
@@ -1,0 +1,12 @@
+laze: executing task echo-all for builder default bin app
+1: first=1
+1: second=2
+1: third=3
+1: all-star
+2: 1 2 3 4
+1: all-at
+2: 1
+3: 2
+4: 3
+5: 4
+1: first=any=first

--- a/src/tests/48_tasks_calling_tasks/args.sh
+++ b/src/tests/48_tasks_calling_tasks/args.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+i=1
+for arg in "$@"; do
+  echo "$i: $arg"
+  i=$(( i +1))
+done

--- a/src/tests/48_tasks_calling_tasks/laze-project.yml
+++ b/src/tests/48_tasks_calling_tasks/laze-project.yml
@@ -1,0 +1,53 @@
+builders:
+  - name: default
+    rules:
+      - name: LINK
+        in: "o"
+        cmd: "cat ${in} > ${out}"
+
+    env:
+      bindir: build/${builder}/${app}
+
+    tasks:
+      echo:
+        cmd:
+          - sh args.sh "$@"
+
+      echo-first:
+        cmd:
+          - :echo first=$1
+
+      echo-second:
+        cmd:
+          - :echo second=$2
+
+      echo-third:
+        cmd:
+          - :echo third=$3
+
+      echo-star:
+        cmd:
+          - :echo all-star $*
+
+      echo-at:
+        cmd:
+          - :echo all-at "$@"
+
+      echo-any:
+        cmd:
+          - :echo-${ANY} any=${ANY} "$@"
+
+      echo-all:
+        cmd:
+          - :echo-first $1 $2 $3 $4
+          - :echo-second $1 $2 $3 $4
+          - :echo-third $1 $2 $3 $4
+          - :echo-star $1 $2 $3 $4
+          - :echo-at $1 $2 $3 $4
+          - :echo-any $1 $2 $3 $4
+      ls:
+        cmd:
+          - ls "$@"
+
+apps:
+  - name: app

--- a/src/tests/48_tasks_calling_tasks/laze-project.yml
+++ b/src/tests/48_tasks_calling_tasks/laze-project.yml
@@ -37,6 +37,23 @@ builders:
         cmd:
           - :echo-${ANY} any=${ANY} "$@"
 
+      echo-with-export:
+        export:
+          - VARIABLE: foo
+        cmd:
+          - :echo-variable
+
+      echo-with-export-two:
+        export:
+          - VARIABLE: bar
+          - ANOTHER_VARIABLE: bar
+        cmd:
+          - :echo-with-export
+
+      echo-variable:
+        cmd:
+          - echo $VARIABLE $ANOTHER_VARIABLE
+
       echo-all:
         cmd:
           - :echo-first $1 $2 $3 $4
@@ -45,6 +62,8 @@ builders:
           - :echo-star $1 $2 $3 $4
           - :echo-at $1 $2 $3 $4
           - :echo-any $1 $2 $3 $4
+          - :echo-with-export
+          - :echo-with-export-two
       ls:
         cmd:
           - ls "$@"

--- a/src/tests/48_tasks_calling_tasks/stdout.tail
+++ b/src/tests/48_tasks_calling_tasks/stdout.tail
@@ -1,4 +1,3 @@
-laze: executing task echo-all for builder default bin app
 1: first=1
 1: second=2
 1: third=3
@@ -10,3 +9,5 @@ laze: executing task echo-all for builder default bin app
 4: 3
 5: 4
 1: first=any=first
+foo
+foo bar

--- a/src/tests/48_tasks_calling_tasks/stdout.tail
+++ b/src/tests/48_tasks_calling_tasks/stdout.tail
@@ -1,0 +1,12 @@
+laze: executing task echo-all for builder default bin app
+1: first=1
+1: second=2
+1: third=3
+1: all-star
+2: 1 2 3 4
+1: all-at
+2: 1
+3: 2
+4: 3
+5: 4
+1: first=any=first

--- a/src/tests/48_tasks_calling_tasks/test.sh
+++ b/src/tests/48_tasks_calling_tasks/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. ../test-common.sh
+
+cleanup
+
+build -DANY=first echo-all 1 2 3 4
+
+echo TEST_OK
+
+cleanup

--- a/src/tests/test-common.sh
+++ b/src/tests/test-common.sh
@@ -31,9 +31,23 @@ build() {
         diff -q EXPECTED_STDOUT stdout
     fi
 
+    if [ -f EXPECTED_STDOUT_TAIL ]; then
+        echo testing stdout tail
+        LEN=$(cat EXPECTED_STDOUT_TAIL | wc -l)
+        cat stdout | tail -n "$LEN" > stdout.tail
+        diff -q EXPECTED_STDOUT_TAIL stdout.tail
+    fi
+
     if [ -f EXPECTED_STDERR ]; then
         echo testing stderr
         diff -q EXPECTED_STDERR stderr
+    fi
+
+    if [ -f EXPECTED_STDERR_TAIL ]; then
+        echo testing stderr tail
+        LEN=$(cat EXPECTED_STDERR_TAIL | wc -l)
+        cat stderr | tail -n "$LEN" > stderr.tail
+        diff -q EXPECTED_STDERR_TAIL stderr.tail
     fi
 
     if [ -f EXPECTED_STDOUT_PATTERNS ]; then
@@ -53,7 +67,7 @@ clean_temp_files() {
         build/laze-cache-local.bincode \
         build/laze-cache-global.bincode \
         compile_commands.json \
-        stdout stderr
+        stdout stderr stdout.tail stderr.tail
 }
 
 : "${LAZE:=laze}"


### PR DESCRIPTION
This allows tasks to call subtasks.

e.g.,

```yaml

tasks:
  echo:
    cmd:
      - echo "$@"
    echo-foo:
      cmd:
      - :echo foo
```

`workdir` will be inherited unless overwritten, `export` will be appended.