### PR TITLE
feat(ninja): use slash paths for ninja files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "indexmap 2.9.0",
  "itertools",
  "mimalloc",
+ "path-slash",
  "pathdiff",
  "rayon",
  "rust-embed",
@@ -1160,6 +1161,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ thiserror = "2.0.12"
 im-rc = "15.1.0"
 shell-words = "1.1.0"
 subst = "0.3.7"
+path-slash = "0.2.1"
 
 [profile.release]
 lto = "fat"

--- a/src/ninja/mod.rs
+++ b/src/ninja/mod.rs
@@ -10,6 +10,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use derive_builder::Builder;
 use im::HashMap;
 use indexmap::IndexMap;
+use path_slash::PathExt as _;
 
 use crate::model::VarExportSpec;
 use crate::nested_env::{self, IfMissing};
@@ -252,14 +253,14 @@ impl fmt::Display for NinjaBuild<'_> {
         write!(f, "build")?;
 
         for out in &self.outs {
-            write!(f, " {out}")?;
+            write!(f, " {}", out.as_std_path().to_slash().unwrap())?;
         }
 
         write!(f, ": $\n    {}", self.rule)?;
 
         if let Some(inputs) = &self.inputs {
             for path in inputs {
-                write!(f, " $\n    {path}")?;
+                write!(f, " $\n    {}", path.as_std_path().to_slash().unwrap())?;
             }
         }
 
@@ -267,7 +268,7 @@ impl fmt::Display for NinjaBuild<'_> {
             write!(f, " $\n    |")?;
             if let Some(list) = &self.deps {
                 for entry in list {
-                    write!(f, " $\n    {entry}")?;
+                    write!(f, " $\n    {}", entry.as_std_path().to_slash().unwrap())?;
                 }
             }
             if self.always {


### PR DESCRIPTION
This PR makes laze write all paths in ninja files (inputs, outputs, deps, `$in`, `$out`) using "slash paths" on both Linux and Windows.

Should fix #705.