### PR TITLE
feat: add `absroot` variable

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -268,6 +268,7 @@ impl Generator {
                     self.disable.as_ref(),
                     &self.cli_env.as_ref(),
                     self.collect_insights,
+                    self.project_root.clone(),
                     verbose,
                 )
                 .with_context(|| format!("binary \"{}\"", bin.name))
@@ -360,6 +361,7 @@ fn configure_build(
     disable: Option<&Vec<String>>,
     cli_env: &Option<&Env>,
     collect_insights: bool,
+    project_root: Utf8PathBuf,
     verbose: bool,
 ) -> Result<ConfigureBuildResult> {
     let mut reason = NoBuildReason::default();
@@ -464,6 +466,9 @@ fn configure_build(
 
     // same with "relroot"
     global_env.insert("relroot".into(), relroot(binary.relpath.as_ref().unwrap()));
+
+    // insert global "absroot"
+    global_env.insert("absroot".into(), project_root);
 
     // insert lists of actually used modules and contexts
     let mut used_modules = Vector::new();


### PR DESCRIPTION
This new variable corresponds to the absolute path to the root of the project.

I'm open to suggestions for the path name. I need the absolute path to set the `LLVM_PROFILE_FILE` for Rust instrumentation/profiling, it seems to bug out when the paths are relative.