### PR TITLE
feat: print help when no subcommand is supplied

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,6 +90,7 @@ pub fn clap() -> clap::Command {
         .author("Kaspar Schleiser <kaspar@schleiser.de>")
         .about("Build a lot, fast")
         .infer_subcommands(true)
+        .subcommand_required(true)
         .arg(
             Arg::new("chdir")
                 .short('C')


### PR DESCRIPTION
This prints the common help output from clap when no ~~argument~~ subcommand is supplied. This does remove the single print statement showing the project root, relpath and project file.

Is there an actual use case for running laze without any subcommand?