### PR TITLE
ci(bencher): install perf

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -23,6 +23,9 @@ jobs:
       BENCHER_ADAPTER: json
 
     steps:
+    - name: install perf
+      run: sudo apt install -y linux-tools-$(uname -r) linux-tools-generic
+
     - name: check out repository code
       uses: actions/checkout@v4
 


### PR DESCRIPTION
`perf` is gone now from the gha ubuntu worker. This seems to be an [upstream bug](https://bugs.launchpad.net/ubuntu/+source/linux-hwe-6.14/+bug/2117159) that made its way to the github images.