### PR TITLE
fix: Prevent panic on flattening empty list

### DIFF
--- a/src/nested_env/mod.rs
+++ b/src/nested_env/mod.rs
@@ -77,7 +77,7 @@ impl EnvKey {
                     res.push_str(suffix);
                 }
             }
-            EnvKey::List(list) => {
+            EnvKey::List(list) if !list.is_empty() => {
                 let joiner = match &opts.joiner {
                     Some(joiner) => joiner,
                     None => " ",
@@ -101,6 +101,7 @@ impl EnvKey {
                     }
                 }
             }
+            _ => (),
         }
         if let Some(end) = &opts.end {
             res.push_str(&end[..]);

--- a/src/nested_env/mod.rs
+++ b/src/nested_env/mod.rs
@@ -513,6 +513,34 @@ mod tests {
     }
 
     #[test]
+    fn test_mergeopts_empty() {
+        let mut env = Env::new();
+        env.insert(
+            "mykey".to_string(),
+            EnvKey::List(vector![]),
+        );
+
+        let mut merge_opts = im::HashMap::new();
+        merge_opts.insert(
+            "mykey".to_string(),
+            MergeOption {
+                joiner: Some(",".to_string()),
+                prefix: Some("P".to_string()),
+                suffix: Some("S".to_string()),
+                start: Some("(".to_string()),
+                end: Some(")".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let flattened = env.flatten_with_opts(&merge_opts).unwrap();
+        assert_eq!(
+            flattened.get("mykey").unwrap(),
+            &"()".to_string()
+        );
+    }
+
+    #[test]
     fn test_assign_from_string_override() {
         let mut env = Env::new();
         env.insert("FOO".to_string(), EnvKey::Single("whiskeyBAR".to_string()));


### PR DESCRIPTION
Laze currently panics when it is build in debug mode and when building Ariel OS on:

```
thread '<unnamed>' panicked at src/nested_env/mod.rs:85:28:
attempt to subtract with overflow
```

This because the length of an empty list is used to subtract 1 from. This PR fixes that case and adds a test to prevent regressions.