### PR TITLE
 feat: add inspect for builders command 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ dependencies = [
  "mimalloc",
  "path-slash",
  "pathdiff",
+ "ptree",
  "rayon",
  "rust-embed",
  "semver",
@@ -1303,6 +1304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "ptree"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "289cfd20ebec0e7ff2572e370dd7a1c9973ba666d3c38c5e747de0a4ada21f17"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ shell-words = "1.1.1"
 subst = "0.3.8"
 path-slash = "0.2.1"
 jobslot = "0.2.23"
+ptree = { version = "0.5.2", default-features = false }
 
 [profile.release]
 lto = "fat"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -209,6 +209,20 @@ pub fn clap() -> clap::Command {
                 .add(SubcommandCandidates::new(task_completer)),
         )
         .subcommand(
+            Command::new("inspect")
+                .about("inspect current configuration")
+                .arg(build_dir())
+                .subcommand(
+                    Command::new("builders").arg(
+                        Arg::new("tree")
+                            .short('t')
+                            .long("tree")
+                            .help("output a tree of the configuration builders")
+                            .action(ArgAction::SetTrue),
+                    ),
+                ),
+        )
+        .subcommand(
             Command::new("clean")
                 .about("clean current configuration")
                 .arg(build_dir())

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,43 @@
+//! Inspect Laze project files, without any build output
+
+use std::io::Write;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use ptree::{write_tree, TreeBuilder};
+
+use crate::{data::load, Context, ContextBag};
+
+pub(crate) struct BuildInspector {
+    contexts: ContextBag,
+}
+
+impl BuildInspector {
+    pub(crate) fn from_project(project_file: Utf8PathBuf, build_dir: Utf8PathBuf) -> Result<Self> {
+        let (contexts, _, _) = load(&project_file, &build_dir)?;
+        Ok(Self { contexts })
+    }
+    pub(crate) fn inspect_builders(&self) -> Vec<&Context> {
+        self.contexts.builders_vec()
+    }
+
+    fn add_tree_element(&self, context: &Context, tree: &mut TreeBuilder) {
+        self.contexts
+            .contexts
+            .iter()
+            .filter(|c| Some(context) == c.get_parent(&self.contexts))
+            .for_each(|c| {
+                tree.begin_child(c.name.to_string());
+                self.add_tree_element(c, tree);
+                tree.end_child();
+            })
+    }
+
+    pub(crate) fn write_tree<W: Write>(&self, w: W) -> Result<()> {
+        let default = self.contexts.get_by_name(&"default".to_string()).unwrap();
+        let mut tree_builder = TreeBuilder::new("default".to_string()); // The first node is always called default
+        self.add_tree_element(default, &mut tree_builder);
+        let tree = tree_builder.build();
+        write_tree(&tree, w).map_err(|e| e.into())
+    }
+}


### PR DESCRIPTION
This adds the first steps for a `laze inspect` subcommand. This PR adds a `laze inspect builders` command to list a flat list of builders available, or with the `--tree` option, a full hierarchy of contexts. 

## Issues/PRs references

Depends on #806 