### PR TITLE
feat: introduce `requires`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,17 @@ pub fn clap() -> clap::Command {
             .add(ArgValueCandidates::new(module_completer))
     }
 
+    fn require() -> Arg {
+        Arg::new("require")
+            .help("only configure builds using these modules")
+            .short('r')
+            .long("requires")
+            .env("LAZE_REQUIRES")
+            .action(ArgAction::Append)
+            .value_delimiter(',')
+            .add(ArgValueCandidates::new(module_completer))
+    }
+
     fn define() -> Arg {
         Arg::new("define")
             .help("set/override variable")
@@ -193,6 +204,7 @@ pub fn clap() -> clap::Command {
                 .next_help_heading("Extra build settings")
                 .arg(select())
                 .arg(disable())
+                .arg(require())
                 .arg(define())
                 .add(SubcommandCandidates::new(task_completer)),
         )

--- a/src/data.rs
+++ b/src/data.rs
@@ -132,6 +132,7 @@ struct YamlContext {
     disables: Option<Vec<String>>,
     provides: Option<Vec<String>>,
     provides_unique: Option<Vec<String>>,
+    requires: Option<Vec<String>>,
     rules: Option<Vec<YamlRule>>,
     var_options: Option<im::HashMap<String, MergeOption>>,
     tasks: Option<HashMap<String, YamlTask>>,
@@ -162,6 +163,7 @@ struct YamlModule {
     provides_unique: Option<Vec<String>>,
     #[serde(alias = "disables")]
     conflicts: Option<Vec<String>>,
+    requires: Option<Vec<String>>,
     #[serde(default = "default_as_false")]
     notify_all: bool,
     sources: Option<Vec<StringOrMapVecString>>,
@@ -596,6 +598,10 @@ pub fn load(
             module.provides = Some(provides.clone());
         }
 
+        if let Some(requires) = context.requires.as_ref() {
+            module.requires = Some(requires.clone());
+        }
+
         if let Some(provides_unique) = context.provides_unique.as_ref() {
             if let Some(provides) = module.provides.as_mut() {
                 provides.extend(provides_unique.iter().cloned());
@@ -750,6 +756,10 @@ pub fn load(
             // practically, it means adding to both "provides" and "conflicts"
             m.add_conflicts(provides_unique);
             m.add_provides(provides_unique);
+        }
+
+        if let Some(requires) = &module.requires {
+            m.add_requires(requires);
         }
 
         if module.notify_all {

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,7 @@ fn try_main() -> Result<i32> {
             // collect CLI selected/disabled modules
             let select = get_selects(build_matches);
             let disable = get_disables(build_matches);
+            let require = get_requires(build_matches);
 
             // collect CLI env overrides
             let cli_env = get_cli_vars(build_matches)?;
@@ -306,6 +307,7 @@ fn try_main() -> Result<i32> {
                 .apps(apps.clone())
                 .select(select)
                 .disable(disable)
+                .require(require)
                 .cli_env(cli_env)
                 .partitioner(partitioner.as_ref().map(|x| format!("{:?}", x)))
                 .collect_insights(info_outfile.is_some())
@@ -547,16 +549,24 @@ fn get_cli_vars(build_matches: &clap::ArgMatches) -> Result<Option<Env>, Error> 
 }
 
 fn get_disables(build_matches: &clap::ArgMatches) -> Option<Vec<String>> {
-    let disable = build_matches
-        .get_many::<String>("disable")
-        .map(|vr| vr.cloned().collect_vec());
-    disable
+    get_string_arg_vec(build_matches, "disable")
+}
+
+fn get_requires(build_matches: &clap::ArgMatches) -> Option<Vec<String>> {
+    get_string_arg_vec(build_matches, "require")
 }
 
 fn get_selects(build_matches: &clap::ArgMatches) -> Option<Vec<Dependency<String>>> {
     let select = build_matches.get_many::<String>("select");
     // convert CLI --select strings to Vec<Dependency>
     select.map(|vr| vr.map(crate::data::dependency_from_string).collect_vec())
+}
+
+fn get_string_arg_vec(build_matches: &clap::ArgMatches, id: &str) -> Option<Vec<String>> {
+    let res = build_matches
+        .get_many::<String>(id)
+        .map(|vr| vr.cloned().collect_vec());
+    res
 }
 
 #[cfg(test)]

--- a/src/model/module.rs
+++ b/src/model/module.rs
@@ -26,6 +26,8 @@ pub struct Module {
     pub imports: Vec<Dependency<String>>,
     pub provides: Option<Vec<String>>,
     pub conflicts: Option<Vec<String>>,
+    pub requires: Option<Vec<String>>,
+
     pub notify_all: bool,
 
     pub blocklist: Option<Vec<String>>,
@@ -253,6 +255,17 @@ impl Module {
         let provides = self.provides.get_or_insert_with(Vec::new);
         for module in provides_unique {
             provides.push(module.as_ref().into());
+        }
+    }
+
+    pub(crate) fn add_requires<I>(&mut self, new_requires: I)
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let requires = self.requires.get_or_insert_with(Vec::new);
+        for module in new_requires {
+            requires.push(module.as_ref().into());
         }
     }
     // returns all fixed and optional sources with srcdir prepended


### PR DESCRIPTION
This introduces a `requires` dependency type.

Any "required" module is not selected or depended on (does not modify dependency resolution), but a build that does not, after dependency resolution is done, contain the required modules in the module set, won't be built.

Use this in laze files to model that something needs a choice but that needs to be explicit:

```
modules:
- name: http-client
  requires:
  - ip
- name: ipv4
  provides:
  - ip
- name: ipv6
  provides:
  - ip
```

Or, use this on cli to select a subset of builds.

Implements #732.