### PR TITLE
download: Don't accept arbitrary values

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -24,7 +24,7 @@ pub mod source {
     }
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
-    #[serde(untagged)]
+    #[serde(untagged, deny_unknown_fields)]
     pub enum Git {
         Commit { url: String, commit: String },
         Branch { url: String, branch: String },


### PR DESCRIPTION
I've been bitten by laze not complaining about unknown keys (a common serde issue), and spent way much more time than I'm happy to admit finding why things broke after I started pinning my version:

```patch
  imports:
    - git:
        url: https://github.com/kaspar030/RIOT-rs
        # from https://github.com/ariel-os/ariel-os/pull/1328
-       branch: bump-embassy-esphal-deps
+       rev: 9baf59181e72baa851e223070c6edbdd8655c470
      dldir: ariel-os
```

Oups -- `rev` is what git calls it. Or was it `refspec`? (That'd be the git argument). Ah: it is `commit`. (Changing the name won't really help: Some people would *expect* this to be commit, and fail in the other direction).

I've only made the change locally for this PR to get discussion started -- do we want this changed everywhere? "Accept everything silently" is IMO not a good setting for a tool that has its own config format. (It's also a bad setting for a tool that uses a more generic config format, but then the tool might not be in a position to change that).

The big downside is that the error message is abysmal (and didn't get better when I tried moving enum fields into separate structs):

```
laze: error: laze-project.yml: imports: data did not match any variant of untagged enum ImportEntry at line 2 column 3
```

I think that's still an improvement over silently picking something I did not intend.