### PR TITLE
docs(book): Add warning about $variables

### DIFF
--- a/book/src/reference/variables.md
+++ b/book/src/reference/variables.md
@@ -23,6 +23,11 @@ modules:
         CFLAGS:
           - -DAPPDIR=\"${appdir}\"
 ```
+
+> [!WARNING]
+> Variables without braces are not evaluated by Laze,
+> and are retained as is in the command.
+
 ## builder
 
 This variable contains the name of the builder.


### PR DESCRIPTION
Might prevent users step into a pitfall with $var vs ${var}