### PR TITLE
docs(book): include envvars.md chapter

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Apps, Builders, Contexts, Modules, Tasks](./concepts/types.md)
 - [Module Dependencies](./concepts/dependencies.md)
 - [Object Sharing](./concepts/object_sharing.md)
+- [Variables and Environment](./concepts/envvars.md)
 
 # Reference
 


### PR DESCRIPTION
This adds the envvars.md file to the book. I don't think it was in there before.