### PR TITLE
feat(generate): extend builder name errors with suggestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "edit-distance"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324d428080b707bac399325341bd61af5ded1b30f33b7c949792ca464733c2d5"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1139,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "derive_builder",
+ "edit-distance",
  "env_logger",
  "evalexpr",
  "git-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ jobslot = "0.2.23"
 ptree = { version = "0.5.2", default-features = false }
 env_logger = "0.11.9"
 log = "0.4.29"
+edit-distance = "2.2.2"
 
 [profile.release]
 lto = "fat"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ mod task_runner;
 mod utils;
 
 use inspect::BuildInspector;
-use model::{Context, ContextBag, Dependency, Module, Rule, Task, TaskError};
+use model::{Context, ContextBag, ContextBagError, Dependency, Module, Rule, Task, TaskError};
 
 use generate::{get_ninja_build_file, BuildInfo, GenerateMode, GeneratorBuilder, Selector};
 use nested_env::{Env, MergeOption};

--- a/src/model/context_bag.rs
+++ b/src/model/context_bag.rs
@@ -262,6 +262,29 @@ impl ContextBag {
         Ok(res)
     }
 
+    pub fn builder_distances(&self, name: impl AsRef<str>) -> Vec<(usize, &Context)> {
+        let mut distances: Vec<_> = self
+            .builders()
+            .map(|b| (edit_distance::edit_distance(name.as_ref(), &b.name), b))
+            .collect();
+
+        distances.sort_by(|a, b| a.0.cmp(&b.0));
+        distances
+    }
+
+    pub fn closest_builder_within(
+        &self,
+        name: impl AsRef<str>,
+        max_distance: usize,
+    ) -> Option<&Context> {
+        if let Some((distance, context)) = self.builder_distances(name).first() {
+            if *distance <= max_distance {
+                return Some(context);
+            }
+        }
+        None
+    }
+
     pub fn context_by_id(&self, context_id: usize) -> &Context {
         &self.contexts[context_id]
     }

--- a/src/model/context_bag.rs
+++ b/src/model/context_bag.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::{iter::Filter, slice::Iter};
 
-use anyhow::{anyhow, Error};
+use camino::Utf8PathBuf;
 use indexmap::IndexSet;
+use thiserror::Error;
 
 use super::{BlockAllow, Context, Module};
 
@@ -18,6 +19,38 @@ pub enum IsAncestor {
     Yes(usize, usize),
 }
 
+#[derive(Error, Debug, Clone)]
+pub enum ContextBagError {
+    #[error("{defined_in:?}: context \"{name}\" has unknown parent \"{parent_name}\"")]
+    UnknownParent {
+        defined_in: Utf8PathBuf,
+        name: String,
+        parent_name: String,
+    },
+    #[error(r#"context name already defined in "{defined_in}""#)]
+    DuplicateContext { defined_in: Utf8PathBuf },
+
+    #[error(r#"{defined_in:?}: module "{name}": undefined context "{context_name}""#)]
+    UndefinedModuleContext {
+        defined_in: Utf8PathBuf,
+        name: String,
+        context_name: String,
+    },
+
+    #[error(r#"{defined_in:?}: module "{name}", context "{context_name}": module name already used in {conflict_in:?}"#)]
+    DuplicateModule {
+        defined_in: Utf8PathBuf,
+        name: String,
+        context_name: String,
+        conflict_in: Utf8PathBuf,
+    },
+
+    #[error("context {name} is not a build context")]
+    NotABuildContext { name: String },
+    #[error("unknown builder {name}")]
+    UnknownBuilder { name: String },
+}
+
 impl ContextBag {
     pub fn new() -> ContextBag {
         Self::default()
@@ -27,7 +60,7 @@ impl ContextBag {
         self.context_map.get(name).map(|id| &self.contexts[*id])
     }
 
-    pub fn finalize(&mut self) -> Result<(), Error> {
+    pub fn finalize(&mut self) -> Result<(), ContextBagError> {
         // ensure there's a "default" context
         if self.get_by_name(&"default".to_string()).is_none() {
             self.add_context(Context::new_default()).unwrap();
@@ -37,12 +70,11 @@ impl ContextBag {
         for context in &mut self.contexts {
             if let Some(parent_name) = &context.parent_name {
                 let parent = self.context_map.get(&parent_name.clone()).ok_or_else(|| {
-                    anyhow!(format!(
-                        "{:?}: context \"{}\" has unknown parent \"{}\"",
-                        context.defined_in.as_ref().unwrap().as_os_str(),
-                        &context.name,
-                        &parent_name
-                    ))
+                    ContextBagError::UnknownParent {
+                        defined_in: context.defined_in.clone().unwrap(),
+                        name: context.name.clone(),
+                        parent_name: parent_name.into(),
+                    }
                 })?;
                 context.parent_index = Some(*parent);
             }
@@ -130,13 +162,13 @@ impl ContextBag {
         &mut self,
         mut context: Context,
         is_builder: bool,
-    ) -> Result<&mut Context, Error> {
+    ) -> Result<&mut Context, ContextBagError> {
         if let Some(context_id) = self.context_map.get(&context.name) {
             let context = self.context_by_id(*context_id);
-            return Err(anyhow!(
-                "context name already defined in {:?}",
-                context.defined_in.as_ref().unwrap()
-            ));
+            return Err(ContextBagError::DuplicateContext {
+                defined_in: context.defined_in.clone().unwrap(),
+            }
+            .into());
         }
 
         let last = self.contexts.len();
@@ -150,31 +182,28 @@ impl ContextBag {
         Ok(&mut self.contexts[last])
     }
 
-    pub fn add_context(&mut self, context: Context) -> Result<&mut Context, Error> {
+    pub fn add_context(&mut self, context: Context) -> Result<&mut Context, ContextBagError> {
         self.add_context_or_builder(context, false)
     }
 
-    pub fn add_module(&mut self, mut module: Module) -> Result<(), Error> {
+    pub fn add_module(&mut self, mut module: Module) -> Result<(), ContextBagError> {
         let context_id = self.context_map.get(&module.context_name).ok_or_else(|| {
-            anyhow!(format!(
-                "{:?}: module \"{}\": undefined context \"{}\"",
-                module.defined_in.as_ref().unwrap().as_os_str(),
-                &module.name,
-                &module.context_name
-            ))
+            ContextBagError::UndefinedModuleContext {
+                defined_in: module.defined_in.clone().unwrap(),
+                name: module.name.clone(),
+                context_name: module.context_name.clone(),
+            }
         })?;
-
         let context = &mut self.contexts[*context_id];
         module.context_id = Some(*context_id);
         match context.modules.entry(module.name.clone()) {
             indexmap::map::Entry::Occupied(other_module) => {
-                return Err(anyhow!(
-                    "{:?}: module \"{}\", context \"{}\": module name already used in {:?}",
-                    module.defined_in.as_ref().unwrap().as_os_str(),
-                    &module.name,
-                    &module.context_name,
-                    other_module.get().defined_in.as_ref().unwrap().as_os_str(),
-                ))
+                return Err(ContextBagError::DuplicateModule {
+                    defined_in: module.defined_in.clone().unwrap(),
+                    name: module.name,
+                    context_name: module.context_name,
+                    conflict_in: other_module.get().defined_in.clone().unwrap(),
+                })
             }
             indexmap::map::Entry::Vacant(entry) => {
                 if let Some(provides) = &module.provides {
@@ -211,7 +240,10 @@ impl ContextBag {
         self.builders().collect()
     }
 
-    pub fn builders_by_name(&self, names: &IndexSet<String>) -> Result<Vec<&Context>, Error> {
+    pub fn builders_by_name(
+        &self,
+        names: &IndexSet<String>,
+    ) -> Result<Vec<&Context>, ContextBagError> {
         let mut res = Vec::new();
         for name in names {
             match self.get_by_name(name) {
@@ -219,13 +251,12 @@ impl ContextBag {
                     if context.is_builder {
                         res.push(context);
                     } else {
-                        return Err(anyhow!(format!(
-                            "context {} is not a build context",
-                            &context.name
-                        )));
+                        return Err(ContextBagError::NotABuildContext {
+                            name: context.name.clone(),
+                        });
                     }
                 }
-                None => return Err(anyhow!(format!("unknown builder {}", &name))),
+                None => return Err(ContextBagError::UnknownBuilder { name: name.into() }),
             }
         }
         Ok(res)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -9,7 +9,7 @@ mod task;
 
 pub use blockallow::BlockAllow;
 pub use context::Context;
-pub use context_bag::{ContextBag, IsAncestor};
+pub use context_bag::{ContextBag, ContextBagError, IsAncestor};
 pub use dependency::Dependency;
 pub use module::{CustomBuild, Module};
 pub use rule::Rule;


### PR DESCRIPTION
This extends the error output when an incorrect builder is supplied by the user with a suggestion for a correct builder. When the edit distance between the supplied incorrect builder and any available builder is too large, no suggestion is made. 

For example:
```Console
$ laze build  --builders nucleo-f401re
laze: project root: ariel-os relpath: . project_file: laze-project.yml
laze: building all for nucleo-f401re
laze: reading cache: cache from different laze version
laze: parsing 77 files took 26.727385ms
laze: stat'ing 77 files took 202.922µs
laze: error: unknown builder nucleo-f401re, did you mean "st-nucleo-f401re"
```

and
```Console
$ laze build  --builders nrf52840
laze: project root: /home/koen/dev/ariel-os relpath: . project_file: laze-project.yml
laze: building all for nrf52840
laze: reading cache: cache from different laze version
laze: parsing 77 files took 27.30444ms
laze: stat'ing 77 files took 220.062µs
laze: error: context nrf52840 is not a build context, did you mean "nrf52840dk"
```

The edit distance is limited, because with a popular embedded Rust operating system it would usually converges to a builder called 'host' for arbitrary invalid names, including 'esp'. At that point the suggestion doesn't help the user anymore

To add only add suggestions to relevant errors, I've converted the `anyhow`-based errors with `ContextBag` to `thiserror`

Depends on #800 