### PR TITLE
refactor(test): fix shellcheck issues

### DIFF
--- a/src/tests/48_tasks_calling_tasks/args.sh
+++ b/src/tests/48_tasks_calling_tasks/args.sh
@@ -2,6 +2,6 @@
 
 i=1
 for arg in "$@"; do
-  echo "$i: $arg"
+  echo "${i}: ${arg}"
   i=$(( i +1))
 done

--- a/src/tests/test-common.sh
+++ b/src/tests/test-common.sh
@@ -1,10 +1,12 @@
+#!/bin/sh
+
 cleanup() {
     rm -f single_app.o single_app.elf build.ninja .ninja_deps .ninja_log stderr stdout
     rm -rf build
 }
 
 diff_build_dir() {
-    if [ "$UPDATE_BUILD_EXPECTED" = 1 ]; then
+    if [ "${UPDATE_BUILD_EXPECTED}" = 1 ]; then
         rm -Rf build_expected
         mv build build_expected
     else
@@ -23,7 +25,8 @@ build() {
 
     if [ -f EXPECTED_EXIT_CODE ]; then
         set -e
-        test "$EXIT_CODE" = "$(cat EXPECTED_EXIT_CODE)"
+        EXPECTED_EXIT_CODE="$(cat EXPECTED_EXIT_CODE)"
+        test "${EXIT_CODE}" = "${EXPECTED_EXIT_CODE}"
     fi
 
     if [ -f EXPECTED_STDOUT ]; then
@@ -34,7 +37,7 @@ build() {
     if [ -f EXPECTED_STDOUT_TAIL ]; then
         echo testing stdout tail
         LEN=$(wc -l < EXPECTED_STDOUT_TAIL)
-        tail -n "$LEN" < stdout > stdout.tail
+        tail -n "${LEN}" < stdout > stdout.tail
         diff -q EXPECTED_STDOUT_TAIL stdout.tail
     fi
 
@@ -46,7 +49,7 @@ build() {
     if [ -f EXPECTED_STDERR_TAIL ]; then
         echo testing stderr tail
         LEN=$(wc -l < EXPECTED_STDERR_TAIL)
-        tail -n "$LEN" < stderr > stderr.tail
+        tail -n "${LEN}" < stderr > stderr.tail
         diff -q EXPECTED_STDERR_TAIL stderr.tail
     fi
 

--- a/src/tests/test-common.sh
+++ b/src/tests/test-common.sh
@@ -33,8 +33,8 @@ build() {
 
     if [ -f EXPECTED_STDOUT_TAIL ]; then
         echo testing stdout tail
-        LEN=$(cat EXPECTED_STDOUT_TAIL | wc -l)
-        cat stdout | tail -n "$LEN" > stdout.tail
+        LEN=$(wc -l < EXPECTED_STDOUT_TAIL)
+        tail -n "$LEN" < stdout > stdout.tail
         diff -q EXPECTED_STDOUT_TAIL stdout.tail
     fi
 
@@ -45,8 +45,8 @@ build() {
 
     if [ -f EXPECTED_STDERR_TAIL ]; then
         echo testing stderr tail
-        LEN=$(cat EXPECTED_STDERR_TAIL | wc -l)
-        cat stderr | tail -n "$LEN" > stderr.tail
+        LEN=$(wc -l < EXPECTED_STDERR_TAIL)
+        tail -n "$LEN" < stderr > stderr.tail
         diff -q EXPECTED_STDERR_TAIL stderr.tail
     fi
 


### PR DESCRIPTION
This fixes a number of potential issues in the test file scripts. Most are just style issues except of [SC2312](https://www.shellcheck.net/wiki/SC2312) found in https://github.com/bergzand/laze/blob/b4aea91dea40ff01a97b5f853d55c09bf10b6c87/src/tests/test-common.sh#L28-L29, which could lead to an incorrect CI false positive. 