### PR TITLE
feat(logging): add colors to the log output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,6 +127,13 @@ pub fn clap() -> clap::Command {
                 .env("LAZE_GLOBAL")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("plain")
+                .long("plain")
+                .help("disable color output on log messages")
+                .global(true)
+                .action(ArgAction::SetTrue),
+        )
         .arg(git_cache::clap_git_cache_dir_arg())
         .subcommand(
             Command::new("build")

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,11 +138,19 @@ fn try_main() -> Result<i32> {
     clap_complete::env::CompleteEnv::with_factory(cli::clap).complete();
 
     let matches = cli::clap().get_matches();
+    let plain = matches.get_flag("plain");
 
     // Set up the logger
     let env = env_logger::Env::default().filter("LAZE_LOG_LEVEL");
     let mut env_log_builder = env_logger::Builder::from_env(env);
-    let log_builder = env_log_builder.format(|buf, record| writeln!(buf, "{}", record.args()));
+    let log_builder = if plain {
+        env_log_builder.format(|buf, record| writeln!(buf, "{}", record.args()))
+    } else {
+        env_log_builder.format(|buf, record| {
+            let style = buf.default_level_style(record.level());
+            writeln!(buf, "{style}{}{style:#}", record.args())
+        })
+    };
 
     let quiet = matches.get_count("quiet");
     let verbose = matches.get_count("verbose");


### PR DESCRIPTION
This adds colors to the log output generated by laze. Default colors as used by env_logger are used here. 

Colors can be disabled by passing the --plain argument, By setting the NO_COLOR environment variable or when the output is not a TTY.