### PR TITLE
feat(completion): make generate shell argument required

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -261,9 +261,10 @@ pub fn clap() -> clap::Command {
             Command::new("completion")
                 .about("Generate laze shell completions.")
                 .arg(
-                    Arg::new("generator")
+                    Arg::new("shell")
                         .help("shell to generate completions for")
                         .long("generate")
+                        .required(true)
                         .value_parser(value_parser!(clap_complete::Shell)),
                 )
                 .hide(true),

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,10 +223,7 @@ fn cmd_completion(matches: &clap::ArgMatches) -> Result<i32> {
             &mut std::io::stdout(),
         );
     }
-    if let Some(generator) = matches
-        .get_one::<clap_complete::Shell>("generator")
-        .copied()
-    {
+    if let Some(generator) = matches.get_one::<clap_complete::Shell>("shell").copied() {
         let mut cmd = cli::clap();
         info!("Generating completion file for {}...", generator);
         print_completions(generator, &mut cmd);


### PR DESCRIPTION
The completion command is silent and without action if no generator is supplied. This commit marks the --generate flag required and clarified the argument name to provide better feedback to the user.