### PR TITLE
feat: simplify variable escaping

### DIFF
--- a/src/nested_env/expand.rs
+++ b/src/nested_env/expand.rs
@@ -47,7 +47,7 @@ where
     SI: AsRef<str>,
 {
     let seen = Vec::new();
-    expand_recursive::<SI>(f, r, seen, if_missing)
+    Ok(unescape(expand_recursive::<SI>(f, r, seen, if_missing)?))
 }
 
 pub fn expand_eval<'b, 'a: 'b, SI>(
@@ -63,9 +63,15 @@ where
 
     let expanded = expand_recursive::<SI>(s, env, seen, if_missing)?;
     let eval_context = EvalContext::new(env);
-    Ok(expanded
-        .eval_with_context(eval_context)
-        .map_err(ExpandError::Expr)?)
+    Ok(unescape(
+        expanded
+            .eval_with_context(eval_context)
+            .map_err(ExpandError::Expr)?,
+    ))
+}
+
+fn unescape(escaped: String) -> String {
+    escaped.replace("\\$", "$")
 }
 
 fn expand_recursive<'a, SI>(
@@ -85,12 +91,17 @@ where
     // Current position in the format string
     let mut cursor = 0;
 
-    let mut escapes = false;
     while cursor < f.len() {
-        if let Some(start) = (f[cursor..]).find("${") {
-            if start > 0 && (&f[cursor..])[start - 1..start] == *"\\" {
+        if let Some(start) = (f[cursor..]).find(['$', '\\']) {
+            let next = &(f[cursor..])[start + 1..start + 2];
+            // skip double $ or '\$'
+            if next == "$" {
+                cursor += start + 2;
+                continue;
+            }
+            //
+            if next != "{" {
                 cursor += start + 1;
-                escapes = true;
                 continue;
             }
             let start = start + cursor;
@@ -154,10 +165,6 @@ where
     // If there's more text after the final `${}`
     if cursor < f.len() {
         result.push_str(&f[cursor..]);
-    }
-
-    if escapes {
-        result = result.replace("\\${", "${");
     }
 
     Ok(result)
@@ -229,10 +236,31 @@ mod tests {
     #[test]
     fn single_expansion_escaped() {
         let mut vars = EnvMap::new();
-        vars.insert("A", "\\${a}".into());
+        vars.insert("A", "$${a}".into());
         assert_eq!(
             expand("${A} simple string", &vars, IfMissing::Error),
-            Ok("${a} simple string".to_string())
+            Ok("$${a} simple string".to_string())
+        );
+    }
+
+    #[test]
+    fn single_expansion_escaped_twice() {
+        let mut vars = EnvMap::new();
+        vars.insert("A", "$$${a}".into());
+        vars.insert("a", "X".into());
+        assert_eq!(
+            expand("${A} simple string", &vars, IfMissing::Error),
+            Ok("$$X simple string".to_string())
+        );
+    }
+
+    #[test]
+    fn single_expansion_backslash() {
+        let mut vars = EnvMap::new();
+        vars.insert("a", "\\${a}".into());
+        assert_eq!(
+            expand("${a}", &vars, IfMissing::Ignore),
+            Ok("${a}".to_string())
         );
     }
 }

--- a/src/nested_env/expr.rs
+++ b/src/nested_env/expr.rs
@@ -45,16 +45,25 @@ fn eval_recursive<'a>(
     let mut start = 0;
     let mut level = 0;
     let mut input_changed = false;
+    let mut in_escape = false;
 
     for (i, character) in input.char_indices() {
-        if character == '$'
-            && i + 1 < input.len()
-            && input[i + 1..i + 2] == *"("
-            && (i == 0 || (input[i - 1..i] != *"$"))
-        {
-            if level == 0 {
-                start = i + 1;
+        if character == '$' {
+            if in_escape {
+                in_escape = false;
+                result.push_str("$");
+                continue;
+            } else {
+                in_escape = true;
             }
+        } else {
+            if in_escape {
+                in_escape = false;
+            }
+        }
+
+        if character == '$' && i + 1 < input.len() && input[i + 1..i + 2] == *"(" && level == 0 {
+            start = i + 1;
         } else if character == '(' && start > 0 {
             level += 1;
         } else if character == ')' && level > 0 && start > 0 {
@@ -122,8 +131,14 @@ mod tests {
     }
     #[test]
     fn escaped_dollar_with_another() {
-        let literal = "$(1) just some $$(1) text";
+        let literal = "$(1+1) just some $$(2+2) text";
         let result = eval(literal);
-        assert_eq!(result.unwrap(), "1 just some $$(1) text");
+        assert_eq!(result.unwrap(), "2 just some $$(2+2) text");
+    }
+    #[test]
+    fn escaped_dollar_with_another_another() {
+        let literal = "$(1+1) just some $$$(2+2) text";
+        let result = eval(literal);
+        assert_eq!(result.unwrap(), "2 just some $$4 text");
     }
 }


### PR DESCRIPTION
This PR makes the variable substitution and expression evaluation ignore double `$` (pass through, don't evaluate).

They then do end up in ninja files, where they count as escaped `$`.
Tasks turn all `$$` into `$` on execution.

