### PR TITLE
docs(readme): add matrix chat room badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Packaging status](https://repology.org/badge/tiny-repos/laze.svg)](https://repology.org/project/laze/versions)
 [![latest packaged version(s)](https://repology.org/badge/latest-versions/laze.svg)](https://repology.org/project/laze/versions)
 ![MSRV](https://img.shields.io/crates/msrv/laze)
+[![Matrix](https://img.shields.io/badge/chat-Matrix-brightgreen.svg)](https://matrix.to/#/#laze:schleiser.de)
 
 <img src="./book/images/logo_col_bg.svg">
 


### PR DESCRIPTION
Adds a badge with link to the laze matrix room in the README.md.

Please check if you want to include this badge and link in the readme, and if the link is correct.